### PR TITLE
Fix broken links

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -5,7 +5,7 @@ These are some of the questions I get asked quite frequently. I'd appreciate it 
 Please make sure you are using the latest version of [EssentialsX](https://ci.ender.zone/job/EssentialsX/) and you have [Vault](https://dev.bukkit.org/bukkit-plugins/vault/) installed on your server. The "**X**" part of Essentials**X** is important - the older versions of Essentials do not work.
 
 ### How do I get permissions to sync across multiple servers
-Connect each LuckPerms installation to the same MySQL/MongoDB server. You can use `/luckperms sync` to pull the latest changes from the database. You can also [setup a Messaging Service](https://github.com/lucko/LuckPerms/wiki/Instant-Update-Propagation#messaging-services) to have your changes sync instantly between servers.
+Connect each LuckPerms installation to the same MySQL/MongoDB server. You can use `/luckperms sync` to pull the latest changes from the database. You can also [setup a Messaging Service](https://github.com/lucko/LuckPerms/wiki/Network-Installation#messaging-service) to have your changes sync instantly between servers.
 
 ### MySQL errors
 

--- a/Installation.md
+++ b/Installation.md
@@ -34,12 +34,12 @@ Most MC shared hosting companies have updated by now, but if your provider still
 
 ---
 ### Internet Connection
-LuckPerms uses a number of [external libraries](https://github.com/lucko/LuckPerms/wiki/External-connections-and-3rd-party-software), some of which are [downloaded automatically at runtime](https://github.com/lucko/LuckPerms/wiki/External-connections-and-3rd-party-software#external-services).
+LuckPerms uses a number of [external libraries](https://github.com/lucko/LuckPerms/wiki/External-connections), some of which are [downloaded automatically at runtime](https://github.com/lucko/LuckPerms/wiki/External-connections#downloading-libraries).
 
 If your server does not have an internet connection, you can install LP locally (where you do have an internet connection), and then copy the content of the `/LuckPerms/lib/` directory to your other server.
 
 ## Compatibility
-Some known compatibility issues are outlined below. In all cases, these issues are out of my control - and there's nothing I can do to resolve them in LuckPerms itself. 🙁 
+Some known compatibility issues are outlined below. In all cases, these issues are out of my control - and there's nothing I can do to resolve them in LuckPerms itself. 🙁
 
 Some of the compatibility issues are resolved in newer releases of the server - but the fixes are not backdated.
 
@@ -55,7 +55,7 @@ Your options are:
 
 ---
 ### Older Minecraft versions
-The main release of LuckPerms is not compatible with Bukkit versions earlier than 1.8.8. 
+The main release of LuckPerms is not compatible with Bukkit versions earlier than 1.8.8.
 
 A LuckPerms release for 1.7.10 can be found on [Jenkins](https://ci.lucko.me/job/LuckPermsLegacy/).
 

--- a/Migration.md
+++ b/Migration.md
@@ -27,7 +27,7 @@ If you have an old permissions setup, or a setup you're not completely happy wit
 ## The process
 The migration process is fairly simple, however it varies slightly for each platform.
 
-1. Firstly, you need to [install LuckPerms](https://github.com/lucko/LuckPerms/wiki/Setup). Don't remove your old permissions plugin yet.
+1. Firstly, you need to [install LuckPerms](https://github.com/lucko/LuckPerms/wiki/Installation). Don't remove your old permissions plugin yet.
 2. Ensure that your old permissions plugin is still enabling properly. The migration process won't work if your old setup is broken.
 3. Start your server - **do not reload** - a full restart is needed when installing LP. 
 
@@ -70,4 +70,4 @@ For example: `/luckperms migration powerfulperms 127.0.0.1:3306 minecraft root p
 ## Errors
 If it seems that the migration command does not exist, check your server's startup log to check if the plugin you are importing from loaded correctly.
 
-If the process doesn't complete and prints an error message, please submit an Issue on GitHub or [contact me here](https://github.com/lucko/LuckPerms/wiki). I'll try to reply to you ASAP.
+If the process doesn't complete and prints an error message, please submit an Issue on GitHub or [contact me here](https://github.com/lucko/LuckPerms/wiki#2-speech_balloon-discord). I'll try to reply to you ASAP.

--- a/Network-Installation.md
+++ b/Network-Installation.md
@@ -1,6 +1,6 @@
 LuckPerms was written from the start with networks of servers in mind. When correctly setup and configured, permissions data will sync between servers and propagate instantly around your network.
 
-When installing LuckPerms across a network, the regular [installation steps](https://github.com/lucko/LuckPerms/wiki/Setup) and [requirements](https://github.com/lucko/LuckPerms/wiki/Setup#requirements) still apply.
+When installing LuckPerms across a network, the regular [installation steps](https://github.com/lucko/LuckPerms/wiki/Installation) and [requirements](https://github.com/lucko/LuckPerms/wiki/Installation#requirements) still apply.
 
 However, there is one additional requirement.
 
@@ -49,7 +49,7 @@ ___
 ## Installing LuckPerms across your network
 Installing LP on a network is fairly easy, however, there are a number of configuration options which need to be changed as you setup each instance.
 
-The more general [Installation](https://github.com/lucko/LuckPerms/wiki/Setup) guide provides details about how to install LuckPerms on a single server instance. This should be followed for each server in your network. (in most cases it's as simple as adding the plugin jar to the plugins/mods folder)
+The more general [Installation](https://github.com/lucko/LuckPerms/wiki/Installation) guide provides details about how to install LuckPerms on a single server instance. This should be followed for each server in your network. (in most cases it's as simple as adding the plugin jar to the plugins/mods folder)
 
 Once LuckPerms has been installed, you need to stop the server, open the main configuration file, and pay particular attention to the following options:
 
@@ -59,7 +59,7 @@ If you want to set permissions or assign group inheritances on a per server basi
 
 This value is used to define a "server" context for all players when they're connected to the instance.
 
-More information about defining server and world specific permissions can be found [here](https://github.com/lucko/LuckPerms/wiki/Advanced-Setup) and [here](https://github.com/lucko/LuckPerms/wiki/Command-Usage#what-is-context).
+More information about defining server and world specific permissions can be found [here](https://github.com/lucko/LuckPerms/wiki/Advanced-Setup) and [here](https://github.com/lucko/LuckPerms/wiki/Context).
 
 #### [`storage-method`](https://github.com/lucko/LuckPerms/wiki/Configuration#storage-method)
 

--- a/Prefixes,-Suffixes-&-Meta.md
+++ b/Prefixes,-Suffixes-&-Meta.md
@@ -1,6 +1,6 @@
 This guide covers how to setup and manage prefixes, suffixes and meta with LuckPerms.
 
-If you are already familiar with these concepts, and just want to view how the commands work, then you should read the "meta" section of the [Command Usage](https://github.com/lucko/LuckPerms/wiki/Command-Usage#meta---lp-user-user-meta---lp-group-group-meta-) page.
+If you are already familiar with these concepts, and just want to view how the commands work, then you should read the [Command Usage: Meta](https://github.com/lucko/LuckPerms/wiki/Command-Usage:-Meta) page.
 
 # Key Definitions
 ### Prefix / Suffix
@@ -63,7 +63,7 @@ This would remove all prefixes set to admin with a weight of 100. I could then r
 
 The command usage for setting prefixes/suffixes temporarily follows the same format as the commands for adding temporary permissions, or parent groups.
 
-The full command usages can be found [**here**](https://github.com/lucko/LuckPerms/wiki/Command-Usage#meta---lp-user-user-meta---lp-group-group-meta-). The commands for adding and removing meta are also documented there.
+The full command usages can be found [**here**](https://github.com/lucko/LuckPerms/wiki/Command-Usage:-Meta). The commands for adding and removing meta are also documented there.
 
 ## How do I see the prefixes/suffixes a user or group has
 The easiest way to debug issues with prefixes/suffixes is to use the info command.

--- a/Usage.md
+++ b/Usage.md
@@ -23,7 +23,7 @@ For example, I might have 3 groups, "default", "moderator" and "admin". I want m
 
 
 # Getting Started
-If you haven't got LuckPerms installed just yet, please refer to the [installation guide](https://github.com/lucko/LuckPerms/wiki/Setup) first.
+If you haven't got LuckPerms installed just yet, please refer to the [installation guide](https://github.com/lucko/LuckPerms/wiki/Installation) first.
 
 Then, please make sure you read the section about [choosing a Storage type](https://github.com/lucko/LuckPerms/wiki/Storage-types) before proceeding. Whilst it is possible to change these options later, it's better to get them right the first time around.
 

--- a/Why-LuckPerms.md
+++ b/Why-LuckPerms.md
@@ -1,4 +1,4 @@
-**Hi there!** 👋 
+**Hi there!** 👋
 
 This page attempts to answer a number of questions/reactions people tend to have when they first discover the project, and address why you should use LuckPerms. It's awesome, I promise!
 
@@ -55,7 +55,7 @@ You can also upload recordings to the web, for easier analysis and reading.
 ___
 
 ### Permission Trees
-LuckPerms allows you [build "permission trees"](https://github.com/lucko/LuckPerms/wiki/Command-Usage#lp-tree) of all permissions known to the server. The data is populated using permissions registered to the server by plugins.
+LuckPerms allows you [build "permission trees"](https://github.com/lucko/LuckPerms/wiki/Command-Usage:-General#lp-tree) of all permissions known to the server. The data is populated using permissions registered to the server by plugins.
 
 As the server runs for longer periods, the tree also grows, as permissions checked for by plugins on the server are added.
 


### PR DESCRIPTION
There were a few links that were broken when you renamed pages, so I've gone and fixed them up. I had to guess a couple of them (namely https://github.com/LuckPerms/wiki/compare/master...Turbotailz:master#diff-12de146f67b96a50067d6ddc807e9926R73 and https://github.com/LuckPerms/wiki/compare/master...Turbotailz:master#diff-ed910981ef0746b8d8e60712cad092caR37 ) but I believe I gave the right links for those. 

Also ignore the edits that remove a space at the end of the line, my Sublime settings auto-remove unnecessary white space on save 😝 