### PR TITLE
Specify exact variant of LuckPerms to be installed on BungeeCord.

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -16,7 +16,7 @@
 ### Can I just install LuckPerms on BungeeCord?
 * The permissions system used on BungeeCord is completely separate from the systems used on the backend Spigot/Sponge server.
 * If you want the permission checks performed by Spigot/Sponge plugins to be handled by LuckPerms, install LuckPerms on your Spigot/Sponge server.
-* If you want the permission checks performed by BungeeCord plugins to be handled by LuckPerms, install LuckPermsBungee on your proxy.
+* If you want the permission checks performed by BungeeCord plugins to be handled by LuckPerms, install the BungeeCord variant of LuckPerms on your proxy.
 * You **can** just install it on the proxy, but any checks which are performed by Spigot/Sponge plugins will not be handled by LuckPerms.
 
 ## Requirements

--- a/Installation.md
+++ b/Installation.md
@@ -16,7 +16,7 @@
 ### Can I just install LuckPerms on BungeeCord?
 * The permissions system used on BungeeCord is completely separate from the systems used on the backend Spigot/Sponge server.
 * If you want the permission checks performed by Spigot/Sponge plugins to be handled by LuckPerms, install LuckPerms on your Spigot/Sponge server.
-* If you want the permission checks performed by BungeeCord plugins to be handled by LuckPerms, install LuckPerms on your proxy.
+* If you want the permission checks performed by BungeeCord plugins to be handled by LuckPerms, install LuckPermsBungee on your proxy.
 * You **can** just install it on the proxy, but any checks which are performed by Spigot/Sponge plugins will not be handled by LuckPerms.
 
 ## Requirements


### PR DESCRIPTION
The generic reference to LuckPerms for BungeeCord may be confusing to LuckPerms newbies. After investing several hours reading documentation -- which is excellent in all other respects -- I am certain that the entry was meant to say LuckPermsBungee.

Also kudos, for creating a separate Wiki repo for these type of changes.

Best regards,
frelling