### PR TITLE
Fixed Typo

### DIFF
--- a/Prefix-&-Suffix-Stacking.md
+++ b/Prefix-&-Suffix-Stacking.md
@@ -43,7 +43,7 @@ The following elements are allowed.
 | `highest_from_group_<group>` | Selects the value with the highest weight, but only if the value was inherited from the given track. |
 | `lowest_from_group_<group>` | Same as above, except takes the value with the lowest weight. |
 | `highest_not_from_group_<group>` | Selects the value with the highest weight, but only if the value was not inherited from the given track. |
-| `highest_not_from_group_<group>` | Same as above, except takes the value with the lowest weight. |
+| `lowest_not_from_group_<group>` | Same as above, except takes the value with the lowest weight. |
 
 ### An example
 For example, on a prison server, you might have 3 types of group. The "gameplay" rank, a user's donor group, and staff groups.


### PR DESCRIPTION
There was a typo in the element placeholders.