### PR TITLE
Implement explanation of timed parents/perms/...

### DIFF
--- a/Command-Usage:-Meta.md
+++ b/Command-Usage:-Meta.md
@@ -64,15 +64,16 @@ ___
 * `[temporary modifier]` - how the temporary permission should be applied
 * `[context...]` - the contexts to set the meta in
 
-Sets a temporary meta key value pair for a user/group. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.
+Sets a temporary meta key value pair for a user/group. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
+LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 
-| Modifier key | Description |
-|--------------|-------------|
+| Modifier key | Description                                                               |
+|--------------|---------------------------------------------------------------------------|
 | `accumulate` | the duration of any existing nodes will just be added to the new duration |
-| `replace` | the longest duration will be kept, any others nodes will be forgotten |
-| `deny` | the command will just fail if you try to add a duplicate temporary node |
+| `replace`    | the longest duration will be kept, any others nodes will be forgotten     |
+| `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
 #### `/lp user/group <user|group> meta unsettemp`  
@@ -153,15 +154,16 @@ ___
 * `[temporary modifier]` - how the temporary permission should be applied
 * `[context...]` - the contexts to add the prefix in
 
-Adds a prefix to a user/group temporarily. You can wrap the prefix in " " quotes to escape spaces. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.
+Adds a prefix to a user/group temporarily. You can wrap the prefix in " " quotes to escape spaces. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
+LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 
-| Modifier key | Description |
-|--------------|-------------|
+| Modifier key | Description                                                               |
+|--------------|---------------------------------------------------------------------------|
 | `accumulate` | the duration of any existing nodes will just be added to the new duration |
-| `replace` | the longest duration will be kept, any others nodes will be forgotten |
-| `deny` | the command will just fail if you try to add a duplicate temporary node |
+| `replace`    | the longest duration will be kept, any others nodes will be forgotten     |
+| `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
 #### `/lp user/group <user|group> meta addtempsuffix`  
@@ -173,15 +175,16 @@ ___
 * `[temporary modifier]` - how the temporary permission should be applied
 * `[context...]` - the contexts to add the suffix in
 
-Adds a suffix to a user/group temporarily. You can wrap the suffix in " " quotes to escape spaces. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.
+Adds a suffix to a user/group temporarily. You can wrap the suffix in " " quotes to escape spaces. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
+LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 
-| Modifier key | Description |
-|--------------|-------------|
+| Modifier key | Description                                                               |
+|--------------|---------------------------------------------------------------------------|
 | `accumulate` | the duration of any existing nodes will just be added to the new duration |
-| `replace` | the longest duration will be kept, any others nodes will be forgotten |
-| `deny` | the command will just fail if you try to add a duplicate temporary node |
+| `replace`    | the longest duration will be kept, any others nodes will be forgotten     |
+| `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
 #### `/lp user/group <user|group> meta settempprefix`  
@@ -195,15 +198,16 @@ ___
 
 Sets a prefix to a user/group temporarily. You can wrap the prefix in " " quotes to escape spaces. This is different from the `addtempprefix` command in that existing prefixes set in the same context are removed when the new prefix is added. Another difference is that the priority argument is optional in the settempprefix command - LuckPerms will dertermine an appropriate value for the priority when the command is ran.
 
-Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.
+Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
+LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 
-| Modifier key | Description |
-|--------------|-------------|
+| Modifier key | Description                                                               |
+|--------------|---------------------------------------------------------------------------|
 | `accumulate` | the duration of any existing nodes will just be added to the new duration |
-| `replace` | the longest duration will be kept, any others nodes will be forgotten |
-| `deny` | the command will just fail if you try to add a duplicate temporary node |
+| `replace`    | the longest duration will be kept, any others nodes will be forgotten     |
+| `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
 #### `/lp user/group <user|group> meta settempsuffix`  
@@ -217,15 +221,16 @@ ___
 
 Sets a suffix to a user/group temporarily. You can wrap the suffix in " " quotes to escape spaces. This is different from the `addtempsuffix` command in that existing suffixes set in the same context are removed when the new suffix is added. Another difference is that the priority argument is optional in the settempsuffix command - LuckPerms will dertermine an appropriate value for the priority when the command is ran.
 
-Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.
+Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
+LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 
-| Modifier key | Description |
-|--------------|-------------|
+| Modifier key | Description                                                               |
+|--------------|---------------------------------------------------------------------------|
 | `accumulate` | the duration of any existing nodes will just be added to the new duration |
-| `replace` | the longest duration will be kept, any others nodes will be forgotten |
-| `deny` | the command will just fail if you try to add a duplicate temporary node |
+| `replace`    | the longest duration will be kept, any others nodes will be forgotten     |
+| `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
 #### `/lp user/group <user|group> meta removetempprefix`  

--- a/Command-Usage:-Parent.md
+++ b/Command-Usage:-Parent.md
@@ -52,7 +52,7 @@ ___
 * `<group>` - the group to remove
 * `[context...]` - the contexts to remove the group in
 
-Removes a parent from the user/group. Add context to it to only remove parents with this specific context.  
+Removes a parent from the user/group.  
 If the removed group was the users primary group, will they be set back to default as primary.
 
 ___
@@ -91,7 +91,7 @@ ___
 * `<group>` - the group to remove
 * `[context...]` - the contexts to remove group in
 
-Removes a tempoary parent from the user/group.D
+Removes a tempoary parent from the user/group.
 
 ___
 #### `/lp user/group <user|group> parent clear`  
@@ -99,7 +99,7 @@ ___
 **Arguments**:  
 * `[context...]` - the contexts to filter by
 
-Removes all parents the user or group has. Add context to it to only remove parents with this specific context.  
+Removes all parents the user or group has.  
 This will add them back to the `default` group.
 
 ___
@@ -109,7 +109,7 @@ ___
 * `<track>` - the track to remove on
 * `[context...]` - the contexts to filter by
 
-Removes all parents from the user/group on a given track. Add context to it to only remove parents with this specific context.
+Removes all parents from the user/group on a given track.
 
 ___
 #### `/lp user <user> parent switchprimarygroup`  

--- a/Command-Usage:-Parent.md
+++ b/Command-Usage:-Parent.md
@@ -52,7 +52,8 @@ ___
 * `<group>` - the group to remove
 * `[context...]` - the contexts to remove the group in
 
-Removes a parent from the user/group.
+Removes a parent from the user/group. Add context to it to only remove parents with this specific context.  
+If the removed group was the users primary group, will they be set back to default as primary.
 
 ___
 #### `/lp user/group <user|group> parent settrack`  
@@ -72,24 +73,25 @@ ___
 * `[temporary modifier]` - how the temporary permission should be applied
 * `[context...]` - the contexts to add the group in
 
-Adds a parent to a user/group temporarily. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.
+Adds a parent to a user/group temporarily. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
+LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 
-| Modifier key | Description |
-|--------------|-------------|
+| Modifier key | Description                                                               |
+|--------------|---------------------------------------------------------------------------|
 | `accumulate` | the duration of any existing nodes will just be added to the new duration |
-| `replace` | the longest duration will be kept, any others nodes will be forgotten |
-| `deny` | the command will just fail if you try to add a duplicate temporary node |
+| `replace`    | the longest duration will be kept, any others nodes will be forgotten     |
+| `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
 #### `/lp user/group <user|group> parent removetemp`  
 **Permission**: luckperms.user.parent.removetemp or luckperms.group.parent.removetemp  
 **Arguments**:  
 * `<group>` - the group to remove
-* `[context...]` - the contexts to add remove group in
+* `[context...]` - the contexts to remove group in
 
-Removes a tempoary parent from the user/group.
+Removes a tempoary parent from the user/group.D
 
 ___
 #### `/lp user/group <user|group> parent clear`  
@@ -97,7 +99,8 @@ ___
 **Arguments**:  
 * `[context...]` - the contexts to filter by
 
-Removes all parents.
+Removes all parents the user or group has. Add context to it to only remove parents with this specific context.  
+This will add them back to the `default` group.
 
 ___
 #### `/lp user/group <user|group> parent cleartrack`  
@@ -106,7 +109,7 @@ ___
 * `<track>` - the track to remove on
 * `[context...]` - the contexts to filter by
 
-Removes all parents from the user/group on a given track.
+Removes all parents from the user/group on a given track. Add context to it to only remove parents with this specific context.
 
 ___
 #### `/lp user <user> parent switchprimarygroup`  

--- a/Command-Usage:-Permission.md
+++ b/Command-Usage:-Permission.md
@@ -30,10 +30,10 @@ ___
 **Permission**: luckperms.user.permission.set or luckperms.group.permission.set  
 **Arguments**:  
 * `<node>` - the permission node to set
-* `<true|false>` - the value to set the permission to
+* `[true|false]` - the value to set the permission to
 * `[context...]` - the contexts to set the permission in
 
-Sets (or gives) a permission for a user/group. Providing a value of "false" will negate the permission.
+Sets (or gives) a permission for a user/group with "true", granting the permission. Providing a value of "false" will negate the permission. Not adding any context will set the permission in context "global".
 
 ___
 #### `/lp user/group <user|group> permission unset`  
@@ -54,15 +54,16 @@ ___
 * `[temporary modifier]` - how the temporary permission should be applied
 * `[context...]` - the contexts to set the permission in
 
-Sets a permission temporarily for a user/group. Providing a value of "false" will negate the permission. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.
+Sets a permission temporarily for a user/group. Providing a value of "false" will negate the permission. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
+LuckPerms uses a format for the relative time similar to the [SimpleDateFormat]() used in java. F.e. is `1M` one month while `1m` is one minute.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 
-| Modifier key | Description |
-|--------------|-------------|
+| Modifier key | Description                                                               |
+|--------------|---------------------------------------------------------------------------|
 | `accumulate` | the duration of any existing nodes will just be added to the new duration |
-| `replace` | the longest duration will be kept, any others nodes will be forgotten |
-| `deny` | the command will just fail if you try to add a duplicate temporary node |
+| `replace`    | the longest duration will be kept, any others nodes will be forgotten     |
+| `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
 #### `/lp user/group <user|group> permission unsettemp`  

--- a/Command-Usage:-Permission.md
+++ b/Command-Usage:-Permission.md
@@ -55,7 +55,7 @@ ___
 * `[context...]` - the contexts to set the permission in
 
 Sets a permission temporarily for a user/group. Providing a value of "false" will negate the permission. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
-LuckPerms uses a format for the relative time similar to the [SimpleDateFormat]() used in java. F.e. is `1M` one month while `1m` is one minute.
+LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. F.e. is `1M` one month while `1m` is one minute.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 

--- a/Context.md
+++ b/Context.md
@@ -19,7 +19,8 @@ Contexts can be combined with each other to form so called "context sets" - simp
 
 Context sets exist in two places:
 
-* LuckPerms internally will calculate what it deems to be a **players** "current context set" - in other words, the contexts which the player currently satisfies. If the player is in the `world_nether` world, then their current context set will contain the `world=world_nether` context.
+* LuckPerms internally will calculate what it deems to be a **players** "current context set" - in other words, the contexts which the player currently satisfies. If the player is in the `world_nether` world, then their current context set will contain the `world=world_nether` context.  
+It's important to point out that players that are currently offline won't have any context set. You can see this by using the `/lp user <user> info` command and check the "Has contextual data" option on the bottom of the output.
 
 * **Each permission, parent/group, prefix/suffix/meta setting** also has it's own context set - indicating the contexts a player must have for the respective permission/parent/meta value to apply.
 

--- a/Usage.md
+++ b/Usage.md
@@ -21,6 +21,15 @@ Users and groups are able to **inherit permissions from each other**. For exampl
 
 For example, I might have 3 groups, "default", "moderator" and "admin". I want moderator to inherit permissions from default, and admin to inherit permissions from moderator.
 
+### Context
+A term that you will encounter quite often in this wiki is "context". Context allows you to change certain behaviours of permissions, groups and similar.  
+
+Lets assume I want to set the permission `essentials.fly` to only work in the world called "creative" for the default group. To do that I just add the contex `world=creative` at the end of the permission set command (right after the true/false).  
+The command would look like this: `/lp group default permission set essentials.fly true world=creative`  
+There is also a pre-defined server context, that can be used to assign permissions, groups, etc. to certain servers only. This as you might have guessed is only useful if you use LuckPerms on multiple connected servers in a network and if they share the same database.
+
+You can also create your very own context to use in LuckPerms.  
+Head over to the [Context page](https://github.com/lucko/LuckPerms/wiki/Context) for more information.
 
 # Getting Started
 If you haven't got LuckPerms installed just yet, please refer to the [installation guide](https://github.com/lucko/LuckPerms/wiki/Installation) first.

--- a/Usage.md
+++ b/Usage.md
@@ -22,14 +22,11 @@ Users and groups are able to **inherit permissions from each other**. For exampl
 For example, I might have 3 groups, "default", "moderator" and "admin". I want moderator to inherit permissions from default, and admin to inherit permissions from moderator.
 
 ### Context
-A term that you will encounter quite often in this wiki is "context". Context allows you to change certain behaviours of permissions, groups and similar.  
+A term that you will encounter quite often with LuckPerms is "context".
 
-Lets assume I want to set the permission `essentials.fly` to only work in the world called "creative" for the default group. To do that I just add the contex `world=creative` at the end of the permission set command (right after the true/false).  
-The command would look like this: `/lp group default permission set essentials.fly true world=creative`  
-There is also a pre-defined server context, that can be used to assign permissions, groups, etc. to certain servers only. This as you might have guessed is only useful if you use LuckPerms on multiple connected servers in a network and if they share the same database.
+**Context** in the most basic sense simply means the **circumstances where something will apply**.
 
-You can also create your very own context to use in LuckPerms.  
-Head over to the [Context page](https://github.com/lucko/LuckPerms/wiki/Context) for more information.
+Contexts are such a fundamental part of the plugin, they have their [very own wiki page](https://github.com/lucko/LuckPerms/wiki/Context) dedicated to explaining their use.
 
 # Getting Started
 If you haven't got LuckPerms installed just yet, please refer to the [installation guide](https://github.com/lucko/LuckPerms/wiki/Installation) first.


### PR DESCRIPTION
I added a small explanation about how the syntax of the relative time (e.g. `1d20m50s`) works.
If the explanation is wrong, let me know and I correct it.