### PR TITLE
Fix wrong links and api information

### DIFF
--- a/Command-Usage:-Parent.md
+++ b/Command-Usage:-Parent.md
@@ -73,8 +73,7 @@ ___
 * `[temporary modifier]` - how the temporary permission should be applied
 * `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to add the group in
 
-Adds a parent to a user/group temporarily. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
-LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
+Adds a parent to a user/group temporarily. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "1mo3d13h45m" will set the permission to expire in 1 month, 3 days, 13 hours and 45 minutes time, while "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 

--- a/Command-Usage:-Permission.md
+++ b/Command-Usage:-Permission.md
@@ -54,8 +54,7 @@ ___
 * `[temporary modifier]` - how the temporary permission should be applied
 * `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the permission in
 
-Sets a permission temporarily for a user/group. Providing a value of "false" will negate the permission. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
-LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. F.e. is `1M` one month while `1m` is one minute.
+Sets a permission temporarily for a user/group. Providing a value of "false" will negate the permission. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "1mo3d13h45m" will set the permission to expire in 1 month, 3 days, 13 hours and 45 minutes time, while "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.
 
 The "temporary modifier" argument allows you to specify how the permission should be accumulated. You can pick between 3 different options.
 

--- a/Developer-API.md
+++ b/Developer-API.md
@@ -49,7 +49,7 @@ If you're using Maven, simply add this to the `dependencies` section of your POM
 <dependencies>
     <dependency>
         <groupId>net.luckperms</groupId>
-        <artifactId>luckperms-api</artifactId>
+        <artifactId>api</artifactId>
         <version>5.0</version>
         <scope>provided</scope>
     </dependency>
@@ -66,7 +66,7 @@ repositories {
 }
 
 dependencies {
-    compile 'net.luckperms:luckperms-api:5.0'
+    compile 'net.luckperms:api:5.0'
 }
 ```
 
@@ -76,7 +76,7 @@ dependencies {
 
 If you want to manually add the API dependency to your classpath, you can obtain the jar by:
 
-1. Navigating to [`https://repo1.maven.org/maven2/net/luckperms/luckperms-api/`](https://repo1.maven.org/maven2/net/luckperms/luckperms-api/)
+1. Navigating to [`https://repo1.maven.org/maven2/net/luckperms/api/`](https://repo1.maven.org/maven2/net/luckperms/api/)
 2. Selecting the version you wish to use
 3. Downloading the jar titled `luckperms-api-x.x.jar`
 
@@ -142,7 +142,7 @@ Now you've added the API classes to your project, and obtained an instance of th
 
 * Some methods are not "main thread friendly", meaning if they are called from the main Minecraft Server thread, the server will lag.
 * This is because many methods conduct I/O with either the file system or the network. 
-* In most cases, these methods return [CompletableFuture](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html)s.
+* In most cases, these methods return [CompletableFutures](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html).
 * Futures can be an initially complex paradigm for some users - however, it is crucial that you have at least a basic understanding of how they work before attempting to use them.
 * As a general rule, it is advised that if it's convenient to do so, you conduct as much work with the API as possible within async scheduler tasks. Some methods don't return futures, but may still involve a number of relatively complex computations.
 

--- a/Developer-API:-Usage.md
+++ b/Developer-API:-Usage.md
@@ -610,17 +610,17 @@ ___
 
 ### Listening to LuckPerms events
 
-All event interfaces can be found in the [`me.lucko.luckperms.api.event`](https://github.com/lucko/LuckPerms/tree/master/api/src/main/java/me/lucko/luckperms/api/event) package. They all extend [`LuckPermsEvent`](https://github.com/lucko/LuckPerms/blob/master/api/src/main/java/me/lucko/luckperms/api/event/LuckPermsEvent.java).
+All event interfaces can be found in the [`net.luckperms.api.event`](https://github.com/lucko/LuckPerms/tree/master/api/src/main/java/net/luckperms/api/event) package. They all extend [`LuckPermsEvent`](https://github.com/lucko/LuckPerms/blob/master/api/src/main/java/net/luckperms/api/event/LuckPermsEvent.java).
 
-To listen to events, you need to obtain the [`EventBus`](https://github.com/lucko/LuckPerms/blob/master/api/src/main/java/me/lucko/luckperms/api/event/EventBus.java) instance, using `LuckPermsApi#getEventBus`.
+To listen to events, you need to obtain the [`EventBus`](https://github.com/lucko/LuckPerms/blob/master/api/src/main/java/net/luckperms/api/event/EventBus.java) instance, using `LuckPermsApi#getEventBus`.
 
 It's usually a good idea to create a separate class for your listeners. Here's a short example class you can reference.
 
 ```java
-import me.lucko.luckperms.api.event.EventBus;
-import me.lucko.luckperms.api.event.log.LogPublishEvent;
-import me.lucko.luckperms.api.event.user.UserLoadEvent;
-import me.lucko.luckperms.api.event.user.track.UserPromoteEvent;
+import net.luckperms.api.event.EventBus;
+import net.luckperms.api.event.log.LogPublishEvent;
+import net.luckperms.api.event.user.UserLoadEvent;
+import net.luckperms.api.event.user.track.UserPromoteEvent;
 
 public class TestListener {
     private final MyPlugin plugin;
@@ -660,4 +660,4 @@ public class TestListener {
 }
 ```
 
-`EventBus#subscribe` returns an [`EventHandler`](https://github.com/lucko/LuckPerms/blob/master/api/src/main/java/me/lucko/luckperms/api/event/EventHandler.java) instance, which can be used to unregister the listener when your plugin disables.
+`EventBus#subscribe` returns an [`EventHandler`](https://github.com/lucko/LuckPerms/blob/master/api/src/main/java/net/luckperms/api/event/EventHandler.java) instance, which can be used to unregister the listener when your plugin disables.


### PR DESCRIPTION
The documentation is broken as it still links to me.lucko.luckperms while it should be net.luckperms which this PR fixes.