### PR TITLE
Revert "Add arguments to command headings and links to context page"

### DIFF
--- a/Command-Usage:-General.md
+++ b/Command-Usage:-General.md
@@ -49,7 +49,7 @@ ___
 Lists some information/data about LuckPerms, including debugging output, statistics, settings, and important values from the configuration. 
 
 ___
-#### `/lp editor [type]`  
+#### `/lp editor`  
 **Permission**: luckperms.editor  
 **Arguments**:  
 * `[type]` - the types to include in the editor session. can be "all", "users" or "groups"
@@ -62,7 +62,7 @@ ___
 Records debugging output and provides you with a link.
 
 ___
-#### `/lp verbose <on|record|off|upload> [filter]`  
+#### `/lp verbose`  
 **Permission**: luckperms.verbose  
 **Arguments**:  
 * `<on|record|off|upload>` - whether to enable/disable logging, or to upload the logged output
@@ -84,7 +84,7 @@ Filters match the start of permissions or the user being checked. You can use `&
 More information can be found [**here**](https://github.com/lucko/LuckPerms/wiki/Verbose)
 
 ___
-#### `/lp tree [scope] [player]`  
+#### `/lp tree`  
 **Permission**: luckperms.tree  
 **Arguments**:  
 * `[scope]` - the root of the tree (specify `.` to include all permissions)
@@ -97,7 +97,7 @@ All arguments are optional. The default selection is `.` (just a dot, which mean
 Scope allows you to only generate a part of the tree. For example, a scope of `luckperms.user` will only return the branch of the tree starting with "luckperms.user".
 
 ___
-#### `/lp search <permission>`  
+#### `/lp search`  
 **Permission**: luckperms.search  
 **Arguments**:  
 * `<permission>` - the permission to search for
@@ -105,7 +105,7 @@ ___
 Searches all users/groups for a specific permission, and returns a paginated list of all found entries. 
 
 ___
-#### `/lp check <user> <permission>`  
+#### `/lp check`  
 **Permission**: luckperms.check  
 **Arguments**:  
 * `<user>` - the user to check
@@ -119,7 +119,7 @@ ___
 Refreshes all cached data with the storage provider, and then uses the plugins Messaging Service (if configured) to "ping" all other connected servers and request that they sync too.
 
 ___
-#### `/lp import <file>`  
+#### `/lp import`  
 **Permission**: luckperms.import  
 **Arguments**:  
 * `<file>` - the file to import from
@@ -127,7 +127,7 @@ ___
 Imports data into LuckPerms from a file. The file must be a list of commands, starting with "/luckperms". This file can be generated using the export command. The file is expected to be in the plugin directory.
 
 ___
-#### `/lp export <file>`  
+#### `/lp export`  
 **Permission**: luckperms.export  
 **Arguments**:  
 * `<file>` - the file to export to
@@ -140,28 +140,17 @@ ___
 Reloads some values from the configuration file. Not all entries are reloaded by this command, and some require a full server reboot to take effect. (storage settings, for example)
 
 ___
-#### `/lp bulkupdate <data type> <action> [action field] [action value] [constraints...]`  
+#### `/lp bulkupdate`  
 **Permission**: **Console Only**  
-**Arguments**:  
-* `<data type>` - the type of data being changed. (can be `all`, `users` or `groups`)
-* `<action>` - the action to perform on the data. (can be `update` or `delete`)
-* `[action field]` - the field to act upon. only required for update actions. (can be `permission`, `server` or `world`)
-* `[action value]` - the value to replace with. only required for update actions
-* `[constraints]` - the constraints required for the update
-
-Allows you to perform a bulk modification to all permission data. A detailed guide on how to use this command can be found [here](https://github.com/lucko/LuckPerms/wiki/Bulk-Editing).
+Allows you to perform a bulk modifiction to all permission data. A detailed guide on how to use this command can be found [here](https://github.com/lucko/LuckPerms/wiki/Bulk-Editing).
 
 ___
-#### `/lp migration <plugin name> [options]`  
+#### `/lp migration`  
 **Permission**: luckperms.migration  
-**Arguments**:  
-* `<plugin name>` - the plugin to migrate data from
-* `[options]` - the options required for certain plugin migrations
-
 Main command used for the migration system. Allows you to import permissions data into LuckPerms from other permission plugins. More information about this feature can be found [here](https://github.com/lucko/LuckPerms/wiki/Migration).
 
 ___
-#### `/lp creategroup <name>`  
+#### `/lp creategroup`  
 **Permission**: luckperms.creategroup  
 **Arguments**:  
 * `<name>` - the name of the group
@@ -169,7 +158,7 @@ ___
 Creates a new group.
 
 ___
-#### `/lp deletegroup <name>`  
+#### `/lp deletegroup`  
 **Permission**: luckperms.deletegroup  
 **Arguments**:  
 * `<name>` - the name of the group
@@ -182,7 +171,7 @@ ___
 Displays a list of all current groups.
 
 ___
-#### `/lp createtrack <name>`  
+#### `/lp createtrack`  
 **Permission**: luckperms.createtrack  
 **Arguments**:  
 * `<name>` - the name of the track
@@ -190,7 +179,7 @@ ___
 Creates a new track.
 
 ___
-#### `/lp deletetrack <name>`  
+#### `/lp deletetrack`  
 **Permission**: luckperms.deletetrack  
 **Arguments**:  
 * `<name>` - the name of the track

--- a/Command-Usage:-Group.md
+++ b/Command-Usage:-Group.md
@@ -35,7 +35,7 @@ ___
 Opens a web interface to edit permissions for the specified group. After changes are saved, a command will be given that you need to run for the changes to take effect.
 
 ___
-#### `/lp group <group> listmembers [page]`  
+#### `/lp group <group> listmembers`  
 **Permission**: luckperms.group.listmembers  
 **Arguments**:  
 * `[page]` - the page to view
@@ -43,7 +43,7 @@ ___
 Gets a list of the other users/groups which inherit directly from this group.
 
 ___
-#### `/lp group <group> setweight <weight>`  
+#### `/lp group <group> setweight`  
 **Permission**: luckperms.group.setweight  
 **Arguments**:  
 * `<weight>` - the weight to set
@@ -51,11 +51,11 @@ ___
 Sets the groups weight value, which determines the order in which groups will be considered when accumulating a users permissions. Higher value = higher weight.
 
 ___
-#### `/lp group <group> setdisplayname <name>`  
+#### `/lp group <group> setdisplayname`  
 **Permission**: luckperms.group.setdisplayname  
 **Arguments**:  
 * `<name>` - the name to set
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the display name in
+* `[context...]` - the contexts to set the display name in
 
 Sets the groups display name. This can effectively be used as an "alias" for the group.
 
@@ -65,15 +65,15 @@ ___
 Displays a list of all of the tracks a group is currently on.
 
 ___
-#### `/lp group <group> clear [context]`  
+#### `/lp group <group> clear`  
 **Permission**: luckperms.group.clear  
 **Arguments**:  
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to filter by
+* `[context...]` - the contexts to filter by
 
 Clears the group's permissions, parent groups and meta.
 
 ___
-#### `/lp group <group> rename <new name>`  
+#### `/lp group <group> rename`  
 **Permission**: luckperms.group.rename  
 **Arguments**:  
 * `<new name>` - the new name for the group
@@ -81,7 +81,7 @@ ___
 Changes a group's name. Note that any members of this group will not know about the change, and will still point to the old group name. If you wish to update this, you'll need to use the bulk change feature to update the existing entries.
 
 ___
-#### `/lp group <group> clone <new name>`  
+#### `/lp group <group> clone`  
 **Permission**: luckperms.group.clone  
 **Arguments**:  
 * `<new name>` - the name of the clone

--- a/Command-Usage:-Log.md
+++ b/Command-Usage:-Log.md
@@ -20,7 +20,7 @@ ___
 *  [/lp log `trackhistory` \<track\> [page]](#lp-log-trackhistory)
 
 ___
-#### `/lp log recent [user] [page]`  
+#### `/lp log recent`  
 **Permission**: luckperms.log.recent  
 **Arguments**:  
 * `[user]` - the name/uuid of the user to filter by
@@ -29,7 +29,7 @@ ___
 Shows a list of recent actions.
 
 ___
-#### `/lp log search <query> [page]`  
+#### `/lp log search`  
 **Permission**: luckperms.log.search  
 **Arguments**:  
 * `<query>` - the query to search for
@@ -38,7 +38,7 @@ ___
 Searches for log entries matching the given query.
 
 ___
-#### `/lp log notify [on|off]`  
+#### `/lp log notify`  
 **Permission**: luckperms.log.notify  
 **Arguments**:  
 * `[on|off]` - whether to enable or disable
@@ -46,15 +46,15 @@ ___
 Toggles log notifications for the sender executing the command.
 
 ___
-#### `/lp log export <file>`  
+#### `/lp log export`  
 **Permission**: luckperms.log.export  
 **Arguments**:  
 * `<file>` - the file to export to
 
-Exports the log to a list of commands, recognisable by the "/lp import" command. This feature should rarely be used, and use of "/lp export" is recommended instead.
+Exports the log to a list of commands, recognisable by the "/lp import" command. This feature should rarely be used, and use of "/lp export" is reccomended instead.
 
 ___
-#### `/lp log userhistory <user> [page]`  
+#### `/lp log userhistory`  
 **Permission**: luckperms.log.userhistory  
 **Arguments**:  
 * `<user>` - the user to search for
@@ -63,7 +63,7 @@ ___
 Searches for log entries acting upon the given user.
 
 ___
-#### `/lp log grouphistory <group> [page]`  
+#### `/lp log grouphistory`  
 **Permission**: luckperms.log.grouphistory  
 **Arguments**:  
 * `<group>` - the group to search for
@@ -72,7 +72,7 @@ ___
 Searches for log entries acting upon the given group.
 
 ___
-#### `/lp log trackhistory <track> [page]`  
+#### `/lp log trackhistory`  
 **Permission**: luckperms.log.trackhistory  
 **Arguments**:  
 * `<track>` - the track to search for

--- a/Command-Usage:-Meta.md
+++ b/Command-Usage:-Meta.md
@@ -36,33 +36,33 @@ ___
 Displays a list of a user/group's inherited meta (options), prefixes and suffixes.
 
 ___
-#### `/lp user/group <user|group> meta set <key> <value> [context...]`  
+#### `/lp user/group <user|group> meta set`  
 **Permission**: luckperms.user.meta.set or luckperms.group.meta.set  
 **Arguments**:  
 * `<key>` - the key to set
 * `<value>` - the value to set the key to
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the meta in
+* `[context...]` - the contexts to set the meta in
 
 Sets a meta key value pair for a user/group. These values can be read and modified by other plugins using Vault or the Sponge Permissions API.
 
 ___
-#### `/lp user/group <user|group> meta unset <key> <value> [context...]`  
+#### `/lp user/group <user|group> meta unset`  
 **Permission**: luckperms.user.meta.unset or luckperms.group.meta.unset  
 **Arguments**:  
 * `<key>` - the key to unset
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to unset the meta in
+* `[context...]` - the contexts to unset the meta in
 
 Unsets a meta key value pair for a user/group.
 
 ___
-#### `/lp user/group <user|group> meta settemp <key> <value> <duration> [temporary modifier] [context...]`  
+#### `/lp user/group <user|group> meta settemp`  
 **Permission**: luckperms.user.meta.settemp or luckperms.group.meta.settemp  
 **Arguments**:  
 * `<key>` - the key to set
 * `<value>` - the value to set the key to
 * `<duration>` - the duration until the meta will expire
 * `[temporary modifier]` - how the temporary permission should be applied
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the meta in
+* `[context...]` - the contexts to set the meta in
 
 Sets a temporary meta key value pair for a user/group. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
 LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
@@ -76,83 +76,83 @@ The "temporary modifier" argument allows you to specify how the permission shoul
 | `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
-#### `/lp user/group <user|group> meta unsettemp <key> [context...]`  
+#### `/lp user/group <user|group> meta unsettemp`  
 **Permission**: luckperms.user.meta.unsettemp or luckperms.group.meta.unsettemp  
 **Arguments**:  
 * `<key>` - the key to unset
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to unset the meta in
+* `[context...]` - the contexts to unset the meta in
 
 Unsets a temporary meta key value pair for a user/group.
 
 ___
-#### `/lp user/group <user|group> meta addprefix <priority> <prefix> [context...]`  
+#### `/lp user/group <user|group> meta addprefix`  
 **Permission**: luckperms.user.meta.addprefix or luckperms.group.meta.addprefix  
 **Arguments**:  
 * `<priority>` - the priority to add the prefix at
 * `<prefix>` - the actual prefix string
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to add the prefix in
+* `[context...]` - the contexts to add the prefix in
 
 Adds a prefix to a user/group. You can wrap the prefix in " " quotes to escape spaces. 
 
 ___
-#### `/lp user/group <user|group> meta addsuffix <priority> <suffix> [context...]`  
+#### `/lp user/group <user|group> meta addsuffix`  
 **Permission**: luckperms.user.meta.addsuffix or luckperms.group.meta.addsuffix  
 **Arguments**:  
 * `<priority>` - the priority to add the suffix at
 * `<suffix>` - the actual suffix string
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to add the suffix in
+* `[context...]` - the contexts to add the suffix in
 
 Adds a suffix to a user/group. You can wrap the suffix in " " quotes to escape spaces. 
 
 ___
-#### `/lp user/group <user|group> meta setprefix [priority] <prefix> [context...]`  
+#### `/lp user/group <user|group> meta setprefix`  
 **Permission**: luckperms.user.meta.setprefix or luckperms.group.meta.setprefix  
 **Arguments**:  
 * `[priority]` - the priority to set the prefix at
 * `<prefix>` - the actual prefix string
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the prefix in
+* `[context...]` - the contexts to set the prefix in
 
-Sets a prefix for a user/group. You can wrap the prefix in " " quotes to escape spaces. This is different from the `addprefix` command in that existing prefixes set in the same context are removed when the new prefix is added. Another difference is that the priority argument is optional in the setprefix command - LuckPerms will determine an appropriate value for the priority when the command is ran.
+Sets a prefix for a user/group. You can wrap the prefix in " " quotes to escape spaces. This is different from the `addprefix` command in that existing prefixes set in the same context are removed when the new prefix is added. Another difference is that the priority argument is optional in the setprefix command - LuckPerms will dertermine an appropriate value for the priority when the command is ran.
 
 ___
-#### `/lp user/group <user|group> meta setsuffix [priority] <suffix> [context...]`  
+#### `/lp user/group <user|group> meta setsuffix`  
 **Permission**: luckperms.user.meta.setsuffix or luckperms.group.meta.setsuffix  
 **Arguments**:  
 * `[priority]` - the priority to set the suffix at
 * `<suffix>` - the actual suffix string
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the suffix in
+* `[context...]` - the contexts to set the suffix in
 
-Sets a suffix for a user/group. You can wrap the suffix in " " quotes to escape spaces. This is different from the `addsuffix` command in that existing suffixes set in the same context are removed when the new suffix is added. Another difference is that the priority argument is optional in the setsuffix command - LuckPerms will determine an appropriate value for the priority when the command is ran.
+Sets a suffix for a user/group. You can wrap the suffix in " " quotes to escape spaces. This is different from the `addsuffix` command in that existing suffixes set in the same context are removed when the new suffix is added. Another difference is that the priority argument is optional in the setsuffix command - LuckPerms will dertermine an appropriate value for the priority when the command is ran.
 
 ___
-#### `/lp user/group <user|group> meta removeprefix <priority> [prefix] [context...]`  
+#### `/lp user/group <user|group> meta removeprefix`  
 **Permission**: luckperms.user.meta.removeprefix or luckperms.group.meta.removeprefix  
 **Arguments**:  
 * `<priority>` - the priority to remove the prefix at
 * `[prefix]` - the actual prefix string
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to remove the prefix in
+* `[context...]` - the contexts to remove the prefix in
 
 Removes a prefix from a user/group. You can wrap the prefix in " " quotes to escape spaces.
 
 ___
-#### `/lp user/group <user|group> meta removesuffix <priority> [suffix] [context...]`  
+#### `/lp user/group <user|group> meta removesuffix`  
 **Permission**: luckperms.user.meta.removesuffix or luckperms.group.meta.removesuffix  
 **Arguments**:  
 * `<priority>` - the priority to remove the suffix at
 * `[suffix]` - the actual suffix string
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to remove the suffix in
+* `[context...]` - the contexts to remove the suffix in
 
 Removes a suffix from a user/group. You can wrap the suffix in " " quotes to escape spaces.
 
 ___
-#### `/lp user/group <user|group> meta addtempprefix <priority> <prefix> <duration> [temporary modifier] [context...]`  
+#### `/lp user/group <user|group> meta addtempprefix`  
 **Permission**: luckperms.user.meta.addtempprefix or luckperms.group.meta.addtempprefix  
 **Arguments**:  
 * `<priority>` - the priority to add the prefix at
 * `<prefix>` - the actual prefix string
 * `<duration>` - the duration until the prefix will expire
 * `[temporary modifier]` - how the temporary permission should be applied
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to add the prefix in
+* `[context...]` - the contexts to add the prefix in
 
 Adds a prefix to a user/group temporarily. You can wrap the prefix in " " quotes to escape spaces. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
 LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
@@ -166,14 +166,14 @@ The "temporary modifier" argument allows you to specify how the permission shoul
 | `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
-#### `/lp user/group <user|group> meta addtempsuffix <priority> <suffix> <duration> [temporary modifier] [context...]`  
+#### `/lp user/group <user|group> meta addtempsuffix`  
 **Permission**: luckperms.user.meta.addtempsuffix or luckperms.group.meta.addtempsuffix  
 **Arguments**:  
 * `<priority>` - the priority to add the suffix at
 * `<suffix>` - the actual suffix string
 * `<duration>` - the duration until the suffix will expire
 * `[temporary modifier]` - how the temporary permission should be applied
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to add the suffix in
+* `[context...]` - the contexts to add the suffix in
 
 Adds a suffix to a user/group temporarily. You can wrap the suffix in " " quotes to escape spaces. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
 LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
@@ -187,14 +187,14 @@ The "temporary modifier" argument allows you to specify how the permission shoul
 | `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
-#### `/lp user/group <user|group> meta settempprefix [priority] <prefix> <duration> [temporary modifier] [context...]`  
+#### `/lp user/group <user|group> meta settempprefix`  
 **Permission**: luckperms.user.meta.settempprefix or luckperms.group.meta.settempprefix  
 **Arguments**:  
 * `[priority]` - the priority to set the prefix at
 * `<prefix>` - the actual prefix string
 * `<duration>` - the duration until the prefix will expire
 * `[temporary modifier]` - how the temporary permission should be applied
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the prefix in
+* `[context...]` - the contexts to set the prefix in
 
 Sets a prefix to a user/group temporarily. You can wrap the prefix in " " quotes to escape spaces. This is different from the `addtempprefix` command in that existing prefixes set in the same context are removed when the new prefix is added. Another difference is that the priority argument is optional in the settempprefix command - LuckPerms will dertermine an appropriate value for the priority when the command is ran.
 
@@ -210,14 +210,14 @@ The "temporary modifier" argument allows you to specify how the permission shoul
 | `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
-#### `/lp user/group <user|group> meta settempsuffix [priority] <suffix> <duration> [temporary modifier] [context...]`  
+#### `/lp user/group <user|group> meta settempsuffix`  
 **Permission**: luckperms.user.meta.settempsuffix or luckperms.group.meta.settempsuffix  
 **Arguments**:  
 * `[priority]` - the priority to set the suffix at
 * `<suffix>` - the actual suffix string
 * `<duration>` - the duration until the suffix will expire
 * `[temporary modifier]` - how the temporary permission should be applied
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the suffix in
+* `[context...]` - the contexts to set the suffix in
 
 Sets a suffix to a user/group temporarily. You can wrap the suffix in " " quotes to escape spaces. This is different from the `addtempsuffix` command in that existing suffixes set in the same context are removed when the new suffix is added. Another difference is that the priority argument is optional in the settempsuffix command - LuckPerms will dertermine an appropriate value for the priority when the command is ran.
 
@@ -233,30 +233,30 @@ The "temporary modifier" argument allows you to specify how the permission shoul
 | `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
-#### `/lp user/group <user|group> meta removetempprefix <priority> [prefix] [context...]`  
+#### `/lp user/group <user|group> meta removetempprefix`  
 **Permission**: luckperms.user.meta.removetempprefix or luckperms.group.meta.removetempprefix  
 **Arguments**:  
 * `<priority>` - the priority to remove the prefix at
 * `[prefix]` - the actual prefix string
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to remove the prefix in
+* `[context...]` - the contexts to remove the prefix in
 
 Removes a tempoary prefix from a user/group. You can wrap the prefix in " " quotes to escape spaces.
 
 ___
-#### `/lp user/group <user|group> meta removetempsuffix <priority> [suffix] [context...]`  
+#### `/lp user/group <user|group> meta removetempsuffix`  
 **Permission**: luckperms.user.meta.removetempsuffix or luckperms.group.meta.removetempsuffix  
 **Arguments**:  
 * `<priority>` - the priority to remove the suffix at
 * `[suffix]` - the actual suffix string
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to remove the suffix in
+* `[context...]` - the contexts to remove the suffix in
 
 Removes a temporary suffix from a user/group. You can wrap the suffix in " " quotes to escape spaces.
 
 ___
-#### `/lp user/group <user|group> meta clear [context...]`  
+#### `/lp user/group <user|group> meta clear`  
 **Permission**: luckperms.user.meta.clear or luckperms.group.meta.clear  
 **Arguments**:  
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to filter by
+* `[context...]` - the contexts to filter by
 
 Removes all meta/prefixes/suffixes.
 

--- a/Command-Usage:-Parent.md
+++ b/Command-Usage:-Parent.md
@@ -28,50 +28,50 @@ ___
 Displays a list of a user/group's parent groups. (groups they inherit from)
 
 ___
-#### `/lp user/group <user|group> parent set <group> [context...]`  
+#### `/lp user/group <user|group> parent set`  
 **Permission**: luckperms.user.parent.set or luckperms.group.parent.set  
 **Arguments**:  
 * `<group>` - the group to set
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the group in
+* `[context...]` - the contexts to set the group in
 
 Sets a user/group's parent. Unlike the "parent add" command, this command will clear all existing groups set at the given context. The add command will simply "add" the group to the existing ones a user/group has. If the command is executed with no context arguments, this command will also update a user's primary group.
 
 ___
-#### `/lp user/group <user|group> parent add <group> [context...]`  
+#### `/lp user/group <user|group> parent add`  
 **Permission**: luckperms.user.parent.add or luckperms.group.parent.add  
 **Arguments**:  
 * `<group>` - the group to add
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to add the group in
+* `[context...]` - the contexts to add the group in
 
 Adds a parent to a user/group. Unlike the "parent set" command, this command will just accumulate the given parent with the ones the user/group already has. No existing parents will be removed from the user, and a user's primary group will be unaffected.
 
 ___
-#### `/lp user/group <user|group> parent remove <group> [context...]`  
+#### `/lp user/group <user|group> parent remove`  
 **Permission**: luckperms.user.parent.remove or luckperms.group.parent.remove  
 **Arguments**:  
 * `<group>` - the group to remove
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to remove the group in
+* `[context...]` - the contexts to remove the group in
 
 Removes a parent from the user/group.  
 If the removed group was the users primary group, will they be set back to default as primary.
 
 ___
-#### `/lp user/group <user|group> parent settrack <track> <group> [context...]`  
+#### `/lp user/group <user|group> parent settrack`  
 **Permission**: luckperms.user.parent.settrack or luckperms.group.parent.settrack  
 **Arguments**:  
 * `<track>` - the track to set on
 * `<group>` - the group to set to, or a number relating to the position of the group on the given track
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the group in
+* `[context...]` - the contexts to set the group in
 
 Sets a users/groups position on a given track. This behaves in the same way as the set command, except it only clears existing groups which are on the specified track. Other parent groups are not affected.
 ___
-#### `/lp user/group <user|group> parent addtemp <group> <duration> [temporary modifier] [context...]`  
+#### `/lp user/group <user|group> parent addtemp`  
 **Permission**: luckperms.user.parent.addtemp or luckperms.group.parent.addtemp  
 **Arguments**:  
 * `<group>` - the group to add
 * `<duration>` - the duration until the group will expire
 * `[temporary modifier]` - how the temporary permission should be applied
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to add the group in
+* `[context...]` - the contexts to add the group in
 
 Adds a parent to a user/group temporarily. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
 LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. I.e. `1M` would be one month while `1m` would be one minute.
@@ -85,34 +85,34 @@ The "temporary modifier" argument allows you to specify how the permission shoul
 | `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
-#### `/lp user/group <user|group> parent removetemp <group> [context...]`  
+#### `/lp user/group <user|group> parent removetemp`  
 **Permission**: luckperms.user.parent.removetemp or luckperms.group.parent.removetemp  
 **Arguments**:  
 * `<group>` - the group to remove
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to remove the group in
+* `[context...]` - the contexts to remove group in
 
 Removes a tempoary parent from the user/group.
 
 ___
-#### `/lp user/group <user|group> parent clear [context...]`  
+#### `/lp user/group <user|group> parent clear`  
 **Permission**: luckperms.user.parent.clear or luckperms.group.parent.clear  
 **Arguments**:  
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to filter by
+* `[context...]` - the contexts to filter by
 
 Removes all parents the user or group has.  
 This will add them back to the `default` group.
 
 ___
-#### `/lp user/group <user|group> parent cleartrack <track> [context...]`  
+#### `/lp user/group <user|group> parent cleartrack`  
 **Permission**: luckperms.user.parent.cleartrack or luckperms.group.parent.cleartrack  
 **Arguments**:  
 * `<track>` - the track to remove on
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to filter by
+* `[context...]` - the contexts to filter by
 
 Removes all parents from the user/group on a given track.
 
 ___
-#### `/lp user <user> parent switchprimarygroup <group>`  
+#### `/lp user <user> parent switchprimarygroup`  
 **Permission**: luckperms.user.parent.switchprimarygroup  
 **Arguments**:  
 * `<group>` - the group to switch to

--- a/Command-Usage:-Permission.md
+++ b/Command-Usage:-Permission.md
@@ -26,33 +26,33 @@ ___
 Displays a list of the permission nodes a user/group has.
 
 ___
-#### `/lp user/group <user|group> permission set <node> [true|false] [context...]`  
+#### `/lp user/group <user|group> permission set`  
 **Permission**: luckperms.user.permission.set or luckperms.group.permission.set  
 **Arguments**:  
 * `<node>` - the permission node to set
-* `[true|false]` - the value to set the permission to (defaults to `true`)
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the permission in
+* `[true|false]` - the value to set the permission to
+* `[context...]` - the contexts to set the permission in
 
 Sets (or gives) a permission for a user/group with "true", granting the permission. Providing a value of "false" will negate the permission. Not adding any context will set the permission in context "global".
 
 ___
-#### `/lp user/group <user|group> permission unset <node> [context...]`  
+#### `/lp user/group <user|group> permission unset`  
 **Permission**: luckperms.user.permission.unset or luckperms.group.permission.unset  
 **Arguments**:  
 * `<node>` - the permission node to unset
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to unset the permission in
+* `[context...]` - the contexts to unset the permission in
 
 Unsets (or removes) a permission for a user/group.
 
 ___
-#### `/lp user/group <user|group> permission settemp <node> <true|false> <duration> [temporary modifier] [context...]`  
+#### `/lp user/group <user|group> permission settemp`  
 **Permission**: luckperms.user.permission.settemp or luckperms.group.permission.settemp  
 **Arguments**:  
 * `<node>` - the permission node to set
 * `<true|false>` - the value to set the permission to
 * `<duration>` - the duration until the permission will expire
 * `[temporary modifier]` - how the temporary permission should be applied
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to set the permission in
+* `[context...]` - the contexts to set the permission in
 
 Sets a permission temporarily for a user/group. Providing a value of "false" will negate the permission. Duration should either be a time period, or a unix timestamp when the permission will expire. e.g. "3d13h45m" will set the permission to expire in 3 days, 13 hours and 45 minutes time. "1482694200" will set the permission to expire at 7:30PM on 25th December 2016.  
 LuckPerms uses a format for the relative time similar to the [SimpleDateFormat](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) used in java. F.e. is `1M` one month while `1m` is one minute.
@@ -66,38 +66,38 @@ The "temporary modifier" argument allows you to specify how the permission shoul
 | `deny`       | the command will just fail if you try to add a duplicate temporary node   |
 
 ___
-#### `/lp user/group <user|group> permission unsettemp <node> [context...]`  
+#### `/lp user/group <user|group> permission unsettemp`  
 **Permission**: luckperms.user.permission.unsettemp or luckperms.group.permission.unsettemp  
 **Arguments**:  
 * `<node>` - the permission node to unset
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to unset the permission in
+* `[context...]` - the contexts to unset the permission in
 
 Unsets a temporary permission for a user/group.
 
 ___
-#### `/lp user/group <user|group> permission check <node> [context...]`  
+#### `/lp user/group <user|group> permission check`  
 **Permission**: luckperms.user.permission.check or luckperms.group.permission.check  
 **Arguments**:  
 * `<node>` - the permission node to check for
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to check for the permission in
+* `[context...]` - the contexts to check for the permission in
 
 Checks to see if a user/group has a certain permission.
 
 ___
-#### `/lp user/group <user|group> permission checkinherits <node> [context...]`  
+#### `/lp user/group <user|group> permission checkinherits`  
 **Permission**: luckperms.user.permission.checkinherits or luckperms.group.permission.checkinherits  
 **Arguments**:  
 * `<node>` - the permission node to check for
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to check for the permission in
+* `[context...]` - the contexts to check for the permission in
 
 Checks to see if a user/group inherits a certain permission, and if so, where from.
 
 ___
-#### `/lp user/group <user|group> permission clear [context...]`  
+#### `/lp user/group <user|group> permission clear`  
 **Permission**: luckperms.user.permission.clear or luckperms.group.permission.clear  
 **Arguments**:  
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to filter by
+* `[context...]` - the contexts to filter by
 
-Removes all permissions from the user or group.
+Removes all permissions.
 
 ___

--- a/Command-Usage:-Track.md
+++ b/Command-Usage:-Track.md
@@ -25,7 +25,7 @@ ___
 Displays the groups in the track.
 
 ___
-#### `/lp track <track> append <group>`  
+#### `/lp track <track> append`  
 **Permission**: luckperms.track.append  
 **Arguments**:  
 * `<group>` - the group to add
@@ -33,7 +33,7 @@ ___
 Adds a group onto the end of the track.
 
 ___
-#### `/lp track <track> insert <group> <position>`  
+#### `/lp track <track> insert`  
 **Permission**: luckperms.track.insert  
 **Arguments**:  
 * `<group>` - the group to insert
@@ -42,7 +42,7 @@ ___
 Inserts a group into a specific position within this track. A position of 1 would place it at the start of the track.
 
 ___
-#### `/lp track <track> remove <group>`  
+#### `/lp track <track> remove`  
 **Permission**: luckperms.track.remove  
 **Arguments**:  
 * `<group>` - the group to remove
@@ -55,7 +55,7 @@ ___
 Removes all groups from the track.
 
 ___
-#### `/lp track <track> rename <new name>`  
+#### `/lp track <track> rename`  
 **Permission**: luckperms.track.rename  
 **Arguments**:  
 * `<new name>` - the new name for the track
@@ -63,7 +63,7 @@ ___
 Changes a track's name.
 
 ___
-#### `/lp track <track> clone <new name>`  
+#### `/lp track <track> clone`  
 **Permission**: luckperms.track.clone  
 **Arguments**:  
 * `<new name>` - the name of the clone

--- a/Command-Usage:-User.md
+++ b/Command-Usage:-User.md
@@ -33,20 +33,20 @@ ___
 Opens a web interface to edit permissions for the specified group. After changes are saved, a command will be given that you need to run for the changes to take effect.
 
 ___
-#### `/lp user <user> promote <track> [context...]`  
+#### `/lp user <user> promote`  
 **Permission**: luckperms.user.promote  
 **Arguments**:  
 * `<track>` - the track to promote along
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to promote in
+* `[context...]` - the contexts to promote in
 
 This command will promote a user along a track. Firstly, the command will check to see if the user is on the track specified in the given contexts. If the user is not on the track, they will be added to the first group on the track. If they are on the track in more than one place, the command will fail. In all other cases, the user will be promoted up the track, and will be removed from the existing group. If the track action affects their primary group, that will be updated too.
 
 ___
-#### `/lp user <user> demote <track> [context...]`  
+#### `/lp user <user> demote`  
 **Permission**: luckperms.user.demote  
 **Arguments**:  
 * `<track>` - the track to demote along
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to demote in
+* `[context...]` - the contexts to demote in
 
 This command will demote a user along a track. Firstly, the command will check to see if the user is on the track specified in the given contexts. If the user is not on the track, or on the track in more than one place, the command will fail. If not, the user will be demoted down the track, and will be removed from the existing group. If the track action affects their primary group, that will be updated too.
 
@@ -56,15 +56,15 @@ ___
 Displays a list of all of the tracks a user is currently on.
 
 ___
-#### `/lp user <user> clear [context...]`  
+#### `/lp user <user> clear`  
 **Permission**: luckperms.user.clear  
 **Arguments**:  
-* `[context...]` - the [contexts](https://github.com/lucko/LuckPerms/wiki/Context) to filter by
+* `[context...]` - the contexts to filter by
 
 Clears the user's permissions, parent groups and meta.
 
 ___
-#### `/lp user <user> clone <user>`  
+#### `/lp user <user> clone`  
 **Permission**: luckperms.user.clone  
 **Arguments**:  
 * `<user>` - the name of the other user


### PR DESCRIPTION
This reverts LuckPerms/wiki#19 as it causes links to no longer work properly.
Alternatively could the links be fixed, but I see no benefit in displaying the arguments in the headers as they are shown and explained in the description.

They can be displayed in the list itself, but the link doesn't need it.