### PR TITLE
Improve FAQ questions

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -27,5 +27,6 @@ This is an intentional behaviour of SpongeForge. As soon as a permission plugin,
 To fix this give the groups and users the required permissions for the plugins.
 
 ### What versions does LuckPerms support?
-The default LuckPerms supports versions from 1.8.8 up to the latest release which is currently 1.15.1.  
-For the version 1.7.10 will you need to use the Legacy version of LuckPerms, which can be found on [Jenkins](https://ci.lucko.me/view/LuckPerms/job/LuckPerms/)
+The latest version of LuckPerms supports MC versions from 1.8.8 up to the latest release which is currently 1.15.1.  
+For the version 1.7.10 will you need to use the Legacy version of LuckPerms, which can be found on [Jenkins](https://ci.lucko.me/view/LuckPerms/job/LuckPerms/).  
+Even older versions are not supported.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,13 +1,11 @@
 # Frequently Asked Questions
 These are some of the questions I get asked quite frequently. I'd appreciate it if you check to see if your question has already been answered here before asking me directly. 😄 
 
-### Prefixes/Suffixes don't show in chat, tab, ...
-LuckPerms doesn't manage the chat, tab list or whereever you want to display the prefix/suffix.  
-You need to use a separate plugin for this. A popular example for a chat plugin is [EssentialsX](https://ci.ender.zone/job/EssentialsX/) with EssentialsXChat, but you may use any plugin that either hooks into [Vault](https://dev.bukkit.org/bukkit-plugins/vault/) or the LuckPerms API.
+### Prefixes/suffixes don't show in chat, tab, etc.
+LuckPerms doesn't manage the chat, tab list, etc, and therefore isn't responsible for actually displaying the prefix/suffix.  
+You need to use a separate plugin for this - some popular chat formatting plugins are listed [here](https://github.com/lucko/LuckPerms/wiki/Prefixes,-Suffixes-&-Meta#displaying-prefixes-and-suffixes).
 
-BungeeCord and Sponge don't have a plugin similar to vault, meaning that the plugin has to hook into the LuckPerms API directly to retrieve and display the prefix/suffix.
-
-A list of (known) supported plugins can be found [here](https://github.com/lucko/LuckPerms/wiki/Prefixes,-Suffixes-&-Meta#displaying-prefixes-and-suffixes).
+If you're using Bukkit, it's likely that you'll also need to install `Vault` alongside your chat/tab plugin, don't forget it!
 
 ### How do I get permissions to sync across multiple servers
 Connect each LuckPerms installation to the same MySQL/MongoDB server. You can use `/luckperms sync` to pull the latest changes from the database. You can also [setup a Messaging Service](https://github.com/lucko/LuckPerms/wiki/Network-Installation#messaging-service) to have your changes sync instantly between servers.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,8 +1,13 @@
 # Frequently Asked Questions
 These are some of the questions I get asked quite frequently. I'd appreciate it if you check to see if your question has already been answered here before asking me directly. 😄 
 
-### I'm using EssentialsChat and it's not working
-Please make sure you are using the latest version of [EssentialsX](https://ci.ender.zone/job/EssentialsX/) and you have [Vault](https://dev.bukkit.org/bukkit-plugins/vault/) installed on your server. The "**X**" part of Essentials**X** is important - the older versions of Essentials do not work.
+### Prefixes/Suffixes don't show in chat, tab, ...
+LuckPerms doesn't manage the chat, tab list or whereever you want to display the prefix/suffix.  
+You need to use a separate plugin for this. A popular example for a chat plugin is [EssentialsX](https://ci.ender.zone/job/EssentialsX/) with EssentialsXChat, but you may use any plugin that either hooks into [Vault](https://dev.bukkit.org/bukkit-plugins/vault/) or the LuckPerms API.
+
+BungeeCord and Sponge don't have a plugin similar to vault, meaning that the plugin has to hook into the LuckPerms API directly to retrieve and display the prefix/suffix.
+
+A list of (known) supported plugins can be found [here](https://github.com/lucko/LuckPerms/wiki/Prefixes,-Suffixes-&-Meta#displaying-prefixes-and-suffixes).
 
 ### How do I get permissions to sync across multiple servers
 Connect each LuckPerms installation to the same MySQL/MongoDB server. You can use `/luckperms sync` to pull the latest changes from the database. You can also [setup a Messaging Service](https://github.com/lucko/LuckPerms/wiki/Network-Installation#messaging-service) to have your changes sync instantly between servers.
@@ -17,6 +22,6 @@ Such as:
 
 Please see [here](https://github.com/lucko/LuckPerms/wiki/Storage-system-errors).
 
-### I use SpongeForge and when I install LuckPerms do plugins no longer work
+### I use SpongeForge and when I install LuckPerms do plugins no longer work for OPs
 This is an intentional behaviour of SpongeForge. As soon as a permission plugin, in this case LuckPerms, is installed will it disable the OP system.  
 To fix this give the groups and users the required permissions for the plugins.

--- a/FAQ.md
+++ b/FAQ.md
@@ -25,3 +25,7 @@ Please see [here](https://github.com/lucko/LuckPerms/wiki/Storage-system-errors)
 ### I use SpongeForge and when I install LuckPerms do plugins no longer work for OPs
 This is an intentional behaviour of SpongeForge. As soon as a permission plugin, in this case LuckPerms, is installed will it disable the OP system.  
 To fix this give the groups and users the required permissions for the plugins.
+
+### What versions does LuckPerms support?
+The default LuckPerms supports versions from 1.8.8 up to the latest release which is currently 1.15.1.  
+For the version 1.7.10 will you need to use the Legacy version of LuckPerms, which can be found on [Jenkins](https://ci.lucko.me/view/LuckPerms/job/LuckPerms/)


### PR DESCRIPTION
I don't see the point of having a FAQ question specificly for/about Essentials and EssentialsX.

Most issues I saw so far regarding Essentials was mostly about the user not using EssentialsXChat (or any other chat plugin for that matter).
The most asked question is still "Why does LP not show prefix/suffix in x?" which __should__ be answered in this FAQ page.