### PR TITLE
Use Duration example in favour of TimeUnit one

### DIFF
--- a/Developer-API:-Usage.md
+++ b/Developer-API:-Usage.md
@@ -285,7 +285,7 @@ Node node = Node.builder("some.node.key").build();
 // and with extra properties!
 Node node = Node.builder("some.node.key")
         .value(false)
-        .expiry(1, TimeUnit.HOURS)
+        .expiry(Duration.ofHours(1))
         .withContext(DefaultContextKeys.SERVER_KEY, "survival")
         .build();
 


### PR DESCRIPTION
Replaces the current example of `.expiry(1, TimeUnit.HOURS)` with `.expiry(Duration.ofHours(1))` to indicate, that you can set more than one time unit.