### PR TITLE
Add section about LuckPerms and AuthMe

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -67,3 +67,16 @@ To fix this, give the groups and users the required permissions for the plugins.
 The latest version of LuckPerms supports MC versions from 1.8.8 up to the latest release which is currently 1.15.2.  
 For the version 1.7.10 will you need to use the Legacy version of LuckPerms, which can be found on [Jenkins](https://ci.lucko.me/view/LuckPerms/job/LuckPerms/).  
 Even older versions are not supported.
+
+### When I install LuckPerms does my server shut down. Why?
+LuckPerms will never shut down your server.  
+In most, if not all cases is the cause another plugin.
+
+If you use AuthMe, make sure to check your console for the following lines:  
+```
+[00:00:10] [Server thread/WARN]: [AuthMe] Aborting initialization of AuthMe: [InjectorReflectionException]: Could not invoke method 'setup' for fr.xephi.authme.permission.PermissionsManager@xxxxxxxx
+[00:00:10] [Server thread/WARN]: [AuthMe] THE SERVER IS GOING TO SHUT DOWN AS DEFINED IN THE CONFIGURATION!
+```  
+If those lines are shown, does it mean that AuthMe shut down the server, due to a specific configuration setting it has by default.
+
+Please open the config.yml of AuthMe and change `forceVaultHook` from false to true, to fix this.

--- a/FAQ.md
+++ b/FAQ.md
@@ -68,15 +68,15 @@ The latest version of LuckPerms supports MC versions from 1.8.8 up to the latest
 For the version 1.7.10 will you need to use the Legacy version of LuckPerms, which can be found on [Jenkins](https://ci.lucko.me/view/LuckPerms/job/LuckPerms/).  
 Even older versions are not supported.
 
-### When I install LuckPerms does my server shut down. Why?
+### When I install LuckPerms my server shuts down
 LuckPerms will never shut down your server.  
 In most, if not all cases is the cause another plugin.
 
 If you use AuthMe, make sure to check your console for the following lines:  
 ```
-[00:00:10] [Server thread/WARN]: [AuthMe] Aborting initialization of AuthMe: [InjectorReflectionException]: Could not invoke method 'setup' for fr.xephi.authme.permission.PermissionsManager@xxxxxxxx
-[00:00:10] [Server thread/WARN]: [AuthMe] THE SERVER IS GOING TO SHUT DOWN AS DEFINED IN THE CONFIGURATION!
+[AuthMe] Aborting initialization of AuthMe: [InjectorReflectionException]: Could not invoke method 'setup' for fr.xephi.authme.permission.PermissionsManager@xxxxxxxx
+[AuthMe] THE SERVER IS GOING TO SHUT DOWN AS DEFINED IN THE CONFIGURATION!
 ```  
-If those lines are shown, does it mean that AuthMe shut down the server, due to a specific configuration setting it has by default.
+If those lines are shown, the server was shut down by AuthMe, due to a configuration setting it has by default.
 
-Please open the config.yml of AuthMe and change `forceVaultHook` from false to true, to fix this.
+To fix, open the AuthMe config.yml and change `forceVaultHook` from false to true.


### PR DESCRIPTION
Added a section, that explains when you use AuthMe and receive an error, that shuts down the server due to AuthMe being AuthMe