### PR TITLE
Fixed some typos 

### DIFF
--- a/Default-Groups.md
+++ b/Default-Groups.md
@@ -38,8 +38,8 @@ Simply use `/lp group <group> setdisplayname <name>`
 This option would mean that all users are still in the "default" group. However, a parent group is configured for default, so it can inherit permissions from a group with a different name.
 
 ```
-/luckperms creategroup member
-/luckperms group default parent add member
+/lp creategroup member
+/lp group default parent add member
 ```
 
 ## Configure default assignments

--- a/Default-Groups.md
+++ b/Default-Groups.md
@@ -39,7 +39,7 @@ This option would mean that all users are still in the "default" group. However,
 
 ```
 /luckperms creategroup member
-/luckperms group default parents add member
+/luckperms group default parent add member
 ```
 
 ## Configure default assignments


### PR DESCRIPTION
There were a few typos on the default groups page under configure-inhertiance