### PR TITLE
Add links and basic styling guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Content for the [LuckPerms wiki](https://github.com/lucko/LuckPerms/wiki).
 ## Basic Styling Guide
 If you link to a different wiki page, use the full URL to that page (`[text](url)`).  
 For linking to a section within the same page, just use the name of the header with a hashtag (`[text](#name)`).
+
+## License
+The content of this repository is licensed under the [Creative Commons Attribution Share Alike 4.0 International (CC-BY-SA-4.0)](https://github.com/LuckPerms/wiki/blob/master/LICENSE.txt)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # LuckPerms Wiki
 
-Content for the LuckPerms wiki.
+Content for the [LuckPerms wiki](https://github.com/lucko/LuckPerms/wiki).
+
+## Basic Styling Guide
+If you link to a different wiki page, use the full URL to that page (`[text](url)`).  
+For linking to a section within the same page, just use the name of the header with a hashtag (`[text](#name)`).


### PR DESCRIPTION
The readme could need some minor improvement.
I so far added the following:
- Link to the actual wiki itself (Easier navigation rather than needing to get the link somewhere else).
- Small information about some rules about styling (Links for other pages and sections within same page so far)
- License-notice.