### PR TITLE
Fix the arg based perms promotion guide to include spigot

### DIFF
--- a/Argument-based-command-permissions.md
+++ b/Argument-based-command-permissions.md
@@ -174,3 +174,16 @@ The arguments which are checked are outlined below.
 | meta unset        | key                   |
 | promote           | track.next-group      |
 | demote            | track.old-group       |
+
+## How do I set it up so players cannot promote other players to or past their own level on a track?
+
+This is a very common question, and quite simple to set up. All you need to do is add these permissions:
+
+| Permission                                                                        | Value                 |
+|-----------------------------------------------------------------------------------|-----------------------|
+| `luckperms.user.promote`                                                          | true                  |
+| `luckperms.user.promote.modify.others `                                           | true                  |
+| `luckperms.user.promote.<track>.<group they cannot promote to or past>`           | false                 |
+| `luckperms.user.promote.<any track you do not want them to be able to promote on>`| false                 |
+
+

--- a/Argument-based-command-permissions.md
+++ b/Argument-based-command-permissions.md
@@ -175,7 +175,7 @@ The arguments which are checked are outlined below.
 | promote           | track.next-group      |
 | demote            | track.old-group       |
 
-## How do I set it up so players cannot promote other players to or past their own level on a track?
+## Promote other players but not to or past their own level on a track
 
 This is a very common question, and quite simple to set up. All you need to do is add these permissions:
 

--- a/Argument-based-command-permissions.md
+++ b/Argument-based-command-permissions.md
@@ -179,11 +179,15 @@ The arguments which are checked are outlined below.
 
 This is a very common question, and quite simple to set up. All you need to do is add these permissions:
 
+### For Sponge and Spigot:
+
 | Permission                                                                        | Value                 |
 |-----------------------------------------------------------------------------------|-----------------------|
 | `luckperms.user.promote`                                                          | true                  |
+| `luckperms.user.promote.*` <--- This in only needed on Sponge                     | false                 |
 | `luckperms.user.promote.modify.others `                                           | true                  |
-| `luckperms.user.promote.<track>.<group they cannot promote to or past>`           | false                 |
-| `luckperms.user.promote.<any track you do not want them to be able to promote on>`| false                 |
+| `luckperms.user.promote.<track>.*`                                                | true                  |
+| `luckperms.user.promote.<track>.<(all\|groups\|they\|cannot\|promote\|to\|or\|past)>`    | false                 |
 
+For the final node, you add all groups in the track they cannot promote to or past, separated by a `|` and all contained within (). For example, you could set `luckperms.user.promote.staff.(admin|owner)` to prevent them from promoting to or past admin on the staff track.
 

--- a/Web-Editor.md
+++ b/Web-Editor.md
@@ -8,6 +8,8 @@ ___
 
 Editor sessions are first created by executing a command on the server.
 
+You can run different commands to open sessions with different scopes:
+
 
 | Scope                            | Command                    |
 |----------------------------------|----------------------------|
@@ -39,7 +41,7 @@ Once you've created and opened the session, you can use the interface to make ch
 
 ### Editor Context
 
-You can add contexts in the editor in addition to in-game. To do so, either click the "Add Contexts" button before adding a permission or simply fill in the `key` and `value` fields after a permission with approriate keys and vaules, such as `world` and `nether`, or `server` and `hub`.
+You can add contexts in the editor in addition to in-game. To do so, either click the "Add Contexts" button before adding a permission or simply fill in the `key` and `value` fields after a permission with appropriate keys and vaules, such as `world` and `nether`, or `server` and `hub`.
  
 Note that a permission can only have one world and one server context at a time. You have to set the same permission again with the other context to make it apply on multiple worlds/servers.
 
@@ -67,7 +69,7 @@ To change the sorting settings, click on the column heading you'd like to sort b
 
 #### Luckperms Nodes
 
-The editor allows you to add or change aspects abouts groups and players such as weight and parents using nodes.
+The editor allows you to add or change aspects about groups and players such as weight and parents using nodes.
 This is all of them, and what they do:
 
 | Function                                                                  | Node                         |

--- a/Web-Editor.md
+++ b/Web-Editor.md
@@ -7,7 +7,6 @@ ___
 ### Getting started
 
 Editor sessions are first created by executing a command on the server.
-
 You can run different commands to open sessions with different scopes:
 
 
@@ -77,8 +76,8 @@ This is all of them, and what they do:
 | **To define a user or group's parent, add:**                              | `group.<parentgroup>`        |
 | **To set a group's displayname, add:**                                    | `displayname.<name>`         |
 | **To set a group's weight, add:**                                         | `weight.<weightnumber>`      |
-| **To add a prefix to a group or player, add:**                            | `prefix.<weight>.<prefix>`   |
-| **To add a suffix to a group or player, add:**                            | `suffix.<weight>.<suffix>`   |
+| **To add a prefix to a group or player, add:**                            | `prefix.<priority>.<prefix>` |
+| **To add a suffix to a group or player, add:**                            | `suffix.<priority>.<suffix>` |
 
 ___
 

--- a/Web-Editor.md
+++ b/Web-Editor.md
@@ -78,6 +78,7 @@ This is all of them, and what they do:
 | **To set a group's weight, add:**                                         | `weight.<weightnumber>`      |
 | **To add a prefix to a group or player, add:**                            | `prefix.<priority>.<prefix>` |
 | **To add a suffix to a group or player, add:**                            | `suffix.<priority>.<suffix>` |
+| **To add meta:**                                                          | `meta.<key>.<value>`         |
 
 ___
 


### PR DESCRIPTION
Only included Sponge before, with Brain's help I've reworked it to universally work for both Sponge and Spigot, and it makes sense now.