### PR TITLE
Updated the list of chat formatting plugins

### DIFF
--- a/Prefixes,-Suffixes-&-Meta.md
+++ b/Prefixes,-Suffixes-&-Meta.md
@@ -86,9 +86,11 @@ Some popular chat formatting plugins which work with LuckPerms + Vault include:
 * [VaultChatFormatter](https://www.spigotmc.org/resources/49016/) - recommended if you just want something simple!
 * [EssentialsX Chat](https://essentialsx.net/downloads.html) - recommended if you already have Essentials on your server
 * [ChatEx](https://dev.bukkit.org/projects/chatex)
-* [DeluxeChat](https://www.spigotmc.org/resources/1277/)
-* [ChatControl](https://www.spigotmc.org/resources/10258/) (paid)
+* [CarbonChat](https://github.com/Hexaoxide/Carbon) (beta)
 * [VentureChat](https://www.spigotmc.org/resources/771/) (paid)
+* [ChatControl](https://www.spigotmc.org/resources/10258/) (paid)
+* [DeluxeChat](https://www.spigotmc.org/resources/1277/) (paid)
+
 
 Some popular tab/nametag formatting plugins which work with LuckPerms + Vault include:
 * [NametagEdit](https://www.spigotmc.org/resources/3836/)

--- a/Prefixes,-Suffixes-&-Meta.md
+++ b/Prefixes,-Suffixes-&-Meta.md
@@ -86,8 +86,8 @@ Some popular chat formatting plugins which work with LuckPerms + Vault include:
 * [VaultChatFormatter](https://www.spigotmc.org/resources/49016/) - recommended if you just want something simple!
 * [EssentialsX Chat](https://essentialsx.net/downloads.html) - recommended if you already have Essentials on your server
 * [ChatEx](https://dev.bukkit.org/projects/chatex)
+* [VentureChat](https://www.spigotmc.org/resources/771/) 
 * [CarbonChat](https://github.com/Hexaoxide/Carbon) (beta)
-* [VentureChat](https://www.spigotmc.org/resources/771/) (paid)
 * [ChatControl](https://www.spigotmc.org/resources/10258/) (paid)
 * [DeluxeChat](https://www.spigotmc.org/resources/1277/) (paid)
 

--- a/Prefixes,-Suffixes-&-Meta.md
+++ b/Prefixes,-Suffixes-&-Meta.md
@@ -88,8 +88,8 @@ Some popular chat formatting plugins which work with LuckPerms + Vault include:
 * [ChatEx](https://dev.bukkit.org/projects/chatex)
 * [VentureChat](https://www.spigotmc.org/resources/771/) 
 * [CarbonChat](https://github.com/Hexaoxide/Carbon) (beta)
-* [ChatControl](https://www.spigotmc.org/resources/10258/) (paid)
 * [DeluxeChat](https://www.spigotmc.org/resources/1277/) (paid)
+* [ChatControl](https://www.spigotmc.org/resources/10258/) (paid)
 
 
 Some popular tab/nametag formatting plugins which work with LuckPerms + Vault include:

--- a/Prefixes,-Suffixes-&-Meta.md
+++ b/Prefixes,-Suffixes-&-Meta.md
@@ -91,7 +91,6 @@ Some popular chat formatting plugins which work with LuckPerms + Vault include:
 * [DeluxeChat](https://www.spigotmc.org/resources/1277/) (paid)
 * [ChatControl](https://www.spigotmc.org/resources/10258/) (paid)
 
-
 Some popular tab/nametag formatting plugins which work with LuckPerms + Vault include:
 * [NametagEdit](https://www.spigotmc.org/resources/3836/)
 * [TAB](https://www.spigotmc.org/resources/57806/)


### PR DESCRIPTION
I added Carbon chat, with a tag saying its in beta, added a premium tag to Deluxechat as it was missing one, and removed it from Venturechat, sense its a free plugin.