### PR TITLE
Add something about the dependencies not downloading to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -86,7 +86,6 @@ To fix, open the AuthMe config.yml and change `forceVaultHook` from false to tru
 ***
 
 ### LuckPerms cannot download the dependencies 
-<!-- or depends? -->
 LuckPerms requires an internet connection to be able to download it's dependencies. If LuckPerms does not have an connection or a host is blocking it, the plugin will **not** work.
 
 > me.lucko.luckperms.common.dependencies.DependencyDownloadException: java.net.ConnectException: Connection refused (Connection refused)
@@ -97,7 +96,7 @@ Do either of the following to resolve this:
 
 - You can install LP locally (where you do have an internet connection), and then copy the content of the `/LuckPerms/libs/` directory to your other server, into the folder `/LuckPerms/libs/`.
 
-- Contact your server host to allow connections from [nexus.lucko.me](https://nexus.lucko.me/repository/maven-central/") and [repo1.maven.org](https://repo1.maven.org/maven2/).
+- Contact your server host to allow connections from [nexus.lucko.me](https://nexus.lucko.me/repository/maven-central/) and [repo1.maven.org](https://repo1.maven.org/maven2/).
 
 
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -85,7 +85,7 @@ To fix, open the AuthMe config.yml and change `forceVaultHook` from false to tru
 
 ### LuckPerms cannot download the dependencies 
 <!-- or depends? -->
-LuckPerms requires an internet connection to be able to download it's dependencies.
+LuckPerms requires an internet connection to be able to download it's dependencies. If LuckPerms does not have an connection or a host is blocking it, the plugin will **not** work.
 
 > me.lucko.luckperms.common.dependencies.DependencyDownloadException: java.net.ConnectException: Connection refused (Connection refused)
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -82,3 +82,20 @@ If you use AuthMe, make sure to check your console for the following lines:
 If those lines are shown, the server was shut down by AuthMe, due to a configuration setting it has by default.
 
 To fix, open the AuthMe config.yml and change `forceVaultHook` from false to true.
+
+### LuckPerms cannot download the dependencies 
+<!-- or depends? -->
+LuckPerms requires an internet connection to be able to download it's dependencies.
+
+> me.lucko.luckperms.common.dependencies.DependencyDownloadException: java.net.ConnectException: Connection refused (Connection refused)
+
+An error like that either means that **a)** the server doesn't have an internet connection or **b)** your host is blocking the connection.
+
+Do either of the following to resolve this:
+
+- You can install LP locally (where you do have an internet connection), and then copy the content of the `/LuckPerms/libs/` directory to your other server, into the folder `/LuckPerms/libs/`.
+
+- Contact your server host to allow connections from [nexus.lucko.me](https://nexus.lucko.me/repository/maven-central/") and [repo1.maven.org](https://repo1.maven.org/maven2/).
+
+
+

--- a/FAQ.md
+++ b/FAQ.md
@@ -83,6 +83,8 @@ If those lines are shown, the server was shut down by AuthMe, due to a configura
 
 To fix, open the AuthMe config.yml and change `forceVaultHook` from false to true.
 
+***
+
 ### LuckPerms cannot download the dependencies 
 <!-- or depends? -->
 LuckPerms requires an internet connection to be able to download it's dependencies. If LuckPerms does not have an connection or a host is blocking it, the plugin will **not** work.


### PR DESCRIPTION
This adds a section to the FAQ, when LuckPerms isn't able to download it's dependencies and how to fix it. 