### PR TITLE
Add PowerRanks and BungeePerms to Migration List

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -20,7 +20,6 @@ If you have an old permissions setup, or a setup you're not completely happy wit
   * PermissionsBukkit
   * PowerRanks
 * BungeeCord
-  * BungeeCord
   * BungeePerms
 * Sponge
   * None!

--- a/Migration.md
+++ b/Migration.md
@@ -18,8 +18,10 @@ If you have an old permissions setup, or a setup you're not completely happy wit
   * PowerfulPerms
   * bPermissions
   * PermissionsBukkit
+  * PowerRanks
 * BungeeCord
   * BungeeCord
+  * BungeePerms
 * Sponge
   * None!
     * Support for migration on Sponge was removed due to API compatibility issues. LuckPerms is now the only supported permissions plugin for Sponge servers, and most users had already migrated or were using LuckPerms already.


### PR DESCRIPTION
Adds BungeePerms and PowerRanks to the list of plugins that you can migrate data from