### PR TITLE
Add extra info to advanced-setup

### DIFF
--- a/pages/Advanced-Setup.md
+++ b/pages/Advanced-Setup.md
@@ -30,7 +30,7 @@ server: global
 include-global: true
 ```
 * /luckperms user Luck set minecraft.command.gamemode true **WILL APPLY**
-* /luckperms user Luck set minecraft.command.gamemode true factions **WILL NOT APPLY**
+* /luckperms user Luck set minecraft.command.gamemode true factions **WILL NOT APPLY** while not on the Server "factions"
 
 #### Example 2
 ```yml
@@ -70,7 +70,7 @@ Example: if a user has a global "fly.use" permission, and then has a negated "fl
 
 * **Temporary permissions will override non-temporary permissions.**
 
-Example: if a user has a false permission set for "test.node", and a temporary true permission set for "test.node", the temporary permission will override the permanent one, and the user will be granted the true node.
+Example: if a user has a false permission set for "test.node", and a temporary true permission set for "test.node", the temporary permission will override the permanent one, and the user will be granted the true node for the duration of it.
 
 * **Wildcard/regex permissions will be overridden by normal permissions**
 
@@ -78,6 +78,7 @@ Example: if a user has a true permission set for "luckperms.\*", and a false per
 
 * **Temporary permissions will override other temporary permissions with a longer expiry time**
 
+Example: if a user has a temporary true permission set for "fly.use" that expires in 1 day, and then has a temporary false permission set for "fly.use" that expires in 1 hour, the temporary permission expiring in 1 hour will override the one expiring in 1 day, and the user will be granted the negative node for the duration of 1 hour.
 
 * **More specific wildcards override less specific ones**
 

--- a/pages/Advanced-Setup.md
+++ b/pages/Advanced-Setup.md
@@ -78,7 +78,7 @@ Example: if a user has a true permission set for "luckperms.\*", and a false per
 
 * **Temporary permissions will override other temporary permissions with a longer expiry time**
 
-Example: if a user has a temporary true permission set for "fly.use" that expires in 1 day, and then has a temporary false permission set for "fly.use" that expires in 1 hour, the temporary permission expiring in 1 hour will override the one expiring in 1 day, and the user will be granted the negative node for the duration of 1 hour.
+Example: if a user has a temporary true permission set for "fly.use" that expires in 1 day, and a temporary false permission set for "fly.use" that expires in 1 hour, the temporary permission expiring in 1 hour will override the one expiring in 1 day, and the user will be granted the negative node for the duration of 1 hour.
 
 * **More specific wildcards override less specific ones**
 

--- a/pages/Advanced-Setup.md
+++ b/pages/Advanced-Setup.md
@@ -30,7 +30,7 @@ server: global
 include-global: true
 ```
 * /luckperms user Luck set minecraft.command.gamemode true **WILL APPLY**
-* /luckperms user Luck set minecraft.command.gamemode true factions **WILL NOT APPLY** while not on the Server "factions"
+* /luckperms user Luck set minecraft.command.gamemode true factions **WILL NOT APPLY** while not on the server "factions"
 
 #### Example 2
 ```yml
@@ -70,7 +70,7 @@ Example: if a user has a global "fly.use" permission, and then has a negated "fl
 
 * **Temporary permissions will override non-temporary permissions.**
 
-Example: if a user has a false permission set for "test.node", and a temporary true permission set for "test.node", the temporary permission will override the permanent one, and the user will be granted the true node for the duration of it.
+Example: if a user has a false permission set for "test.node", and a temporary true permission set for "test.node", the temporary permission will override the permanent one, and the user will be granted the true node for the duration defined for that temporary permission.
 
 * **Wildcard/regex permissions will be overridden by normal permissions**
 
@@ -78,7 +78,7 @@ Example: if a user has a true permission set for "luckperms.\*", and a false per
 
 * **Temporary permissions will override other temporary permissions with a longer expiry time**
 
-Example: if a user has a temporary true permission set for "fly.use" that expires in 1 day, and a temporary false permission set for "fly.use" that expires in 1 hour, the temporary permission expiring in 1 hour will override the one expiring in 1 day, and the user will be granted the negative node for the duration of 1 hour.
+Example: if a user has a temporary true permission set for "fly.use" that expires in 1 day, and a temporary false permission set for "fly.use" that expires in 1 hour, the temporary permission expiring in 1 hour will override the one expiring in 1 day, and the negative node will take precendence for the duration of 1 hour.
 
 * **More specific wildcards override less specific ones**
 


### PR DESCRIPTION
The [Advanced Setup](https://luckperms.net/wiki/Advanced-Setup) page was imo a bit unlcear at certain parts, namely:

- Didn't mention why the server-specific node wouldn't be applied (or when it wouldn't)
- No example for the temp perms overriding temp perms with higher duration (The bullet point also has increased spacing for no reason).

I changed those two things.
In addition would I suggest two things:

- Fix default code block (No highlighting) actually depicting "group" in green colour (See image below)
- Improve shorthand example by mentioning how the range option works with letters and numbers (how it's ordered and if you can actually combine numbers and letters (e.g. `1-z` or `1a-9z`)

The Odd bulletpoints mentioned
![image](https://user-images.githubusercontent.com/11576465/110270869-173c9d80-7fc7-11eb-82c4-e550d2a5f80a.png)
