### PR TITLE
Add Gradle Kotlin DSL snippet to developer api page

### DIFF
--- a/pages/Developer-API.md
+++ b/pages/Developer-API.md
@@ -60,6 +60,7 @@ If you're using Maven, simply add this to the `dependencies` section of your POM
 
 If you're using Gradle, you need to add these lines to your build script.
 
+##### Groovy DSL:
 ```gradle
 repositories {
     mavenCentral()
@@ -67,6 +68,17 @@ repositories {
 
 dependencies {
     compileOnly 'net.luckperms:api:5.3'
+}
+```
+
+##### Kotlin DSL:
+```kotlin
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly("net.luckperms:api:5.3")
 }
 ```
 


### PR DESCRIPTION
When you use the Kotlin DSL it can get really annoying to replace the ' with " and add parentheses everytime you want to add a dependency to your build script. Also the default dsl of the `gradle init` command is kotlin. I would find it more convenient if both DSLs are on the developer API page.