### PR TITLE
Switch parent/inherited group checking method.

### DIFF
--- a/pages/Developer-API-Usage.md
+++ b/pages/Developer-API-Usage.md
@@ -36,15 +36,15 @@ ___
 
 ### Checking if a player is in a group
 
-Checking for group membership can be most easily achieved using hasPermission checks.
+Checking for group membership can be most easily achieved using `isPermissionSet`.
 
 ```java
 public static boolean isPlayerInGroup(Player player, String group) {
-    return player.hasPermission("group." + group);
+    return player.isPermissionSet("group." + group);
 }
 ```
 
-However, keep in mind that anyone with server operator status or `*` permissions will also have these permissions.
+We use `isPermissionSet` because anyone with server operator status or `*` permissions will also have these permissions.
 
 ___
 
@@ -55,7 +55,7 @@ We can use the method above with a list of "possible" groups in order to find a 
 ```java
 public static String getPlayerGroup(Player player, Collection<String> possibleGroups) {
     for (String group : possibleGroups) {
-        if (player.hasPermission("group." + group)) {
+        if (player.isPermissionSet("group." + group)) {
             return group;
         }
     }


### PR DESCRIPTION
I believe this is a more appropriate method to check for parent/inherited groups compared to `hasPermission` because of the whole "operator status or `*`" thing. Thoughts?

The example was Bukkit-specific already so I didn't bother caring about the method existing on other platforms or not, really.