### PR TITLE
Fix prefix suffix node builder parameters.

### DIFF
--- a/pages/Developer-API-Usage.md
+++ b/pages/Developer-API-Usage.md
@@ -315,10 +315,10 @@ RegexPermissionNode node = RegexPermissionNode.builder(pattern).build();
 InheritanceNode node = InheritanceNode.builder(group).build();
 
 // build a prefix node
-PrefixNode node = PrefixNode.builder(100, "[Some Prefix]").build();
+PrefixNode node = PrefixNode.builder("[Some Prefix]", 100).build();
 
 // build a suffix node
-SuffixNode node = SuffixNode.builder(150, "[Some Suffix]").build();
+SuffixNode node = SuffixNode.builder("[Some Suffix]", 150).build();
 
 // build a metadata node
 MetaNode node = MetaNode.builder("some-key", "some-value").build();


### PR DESCRIPTION
Not sure if it's due to an API change or typo, but in the latest API its `PrefixNode#builder​(@NonNull String suffix, int priority)`, likewise for Suffix node.