### PR TITLE
Bump API release to 5.4

### DIFF
--- a/pages/Developer-API.md
+++ b/pages/Developer-API.md
@@ -6,7 +6,7 @@ LuckPerms has a complete developer API, which allows other plugins on the server
 
 The API uses [Semantic Versioning](https://semver.org/), meaning whenever a non-backwards compatible change is made, the major version will increment. You can rest assured knowing your integration will not break between versions, providing the major version remains the same.
 
-The current API release is `5.3`.
+The current API release is `5.4`.
 
 * The API package in LuckPerms is `net.luckperms.api`.
 * JavaDocs are available either in [a standard JavaDoc layout](https://javadoc.io/doc/net.luckperms/api/), or within the API [source code](https://github.com/lucko/LuckPerms/tree/master/api/src/main/java/net/luckperms/api).
@@ -50,7 +50,7 @@ If you're using Maven, simply add this to the `dependencies` section of your POM
     <dependency>
         <groupId>net.luckperms</groupId>
         <artifactId>api</artifactId>
-        <version>5.3</version>
+        <version>5.4</version>
         <scope>provided</scope>
     </dependency>
 </dependencies>
@@ -67,7 +67,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'net.luckperms:api:5.3'
+    compileOnly 'net.luckperms:api:5.4'
 }
 ```
 
@@ -78,7 +78,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("net.luckperms:api:5.3")
+    compileOnly("net.luckperms:api:5.4")
 }
 ```
 


### PR DESCRIPTION
Version 5.4 of the LuckPerms API was released ([commit](https://github.com/LuckPerms/LuckPerms/commit/99c3d68d3a618677800fd674363855ae143f4452)), this pull request updates the Developer API page to:
 - Bump the "current API release" note to 5.4,
 - Update the dependency blocks to 5.4