### PR TITLE
Add link to Minecraft Command Permissions to FAQ

### DIFF
--- a/pages/FAQ.md
+++ b/pages/FAQ.md
@@ -10,7 +10,7 @@ First, *make sure LuckPerms is your only permission plugin!* We have had many is
 
 If LuckPerms is your only permission plugin, then the issue could be that you have not added the correct permissions for what you require. Always make sure to consult the documentation of the plugins you are using to see what the available permissions are. If the documentation is incomplete or you're unable to find any, then you can use [Verbose mode](Verbose) to see which permissions are being checked in real-time and what value LuckPerms returns for the user that is being checked.
 
-If you are running a Fabric server with LuckPerms, you **cannot use permissions with vanilla commands**. Unlike Bukkit/Spigot and Sponge, Fabric does not add permission checks for vanilla commands. This is not an issue with LuckPerms and it's something that may change in the future.
+If you are running a Fabric server with LuckPerms, you **cannot use permissions with vanilla commands**. Unlike Bukkit/Spigot and Sponge, Fabric does not add permission checks for vanilla commands. This is not an issue with LuckPerms. However, since Fabric supports modifying the base game, you may install an additional mod to add those permission checks, such as [Minecraft Command Permissions](https://github.com/lucko/minecraft-command-permissions-fabric).
 
 Also note that individual mods may not support permissions either, as permissions in Fabric are not yet as standardized as they are in Bukkit/Spigot or Sponge.
 


### PR DESCRIPTION
I have to resist the urge to link [my own mod](https://github.com/LoganDark/fabric-command-hider) because the version of Fabric Loader that it requires hasn't released yet.