### PR TITLE
Add link to Command Hider in FAQ

### DIFF
--- a/pages/FAQ.md
+++ b/pages/FAQ.md
@@ -10,7 +10,7 @@ First, *make sure LuckPerms is your only permission plugin!* We have had many is
 
 If LuckPerms is your only permission plugin, then the issue could be that you have not added the correct permissions for what you require. Always make sure to consult the documentation of the plugins you are using to see what the available permissions are. If the documentation is incomplete or you're unable to find any, then you can use [Verbose mode](Verbose) to see which permissions are being checked in real-time and what value LuckPerms returns for the user that is being checked.
 
-If you are running a Fabric server with LuckPerms, you **cannot use permissions with vanilla commands**. Unlike Bukkit/Spigot and Sponge, Fabric does not add permission checks for vanilla commands. This is not an issue with LuckPerms. However, since Fabric supports modifying the base game, you may install an additional mod to add those permission checks, such as [Minecraft Command Permissions](https://github.com/lucko/minecraft-command-permissions-fabric).
+If you are running a Fabric server with LuckPerms, you **cannot use permissions with vanilla commands**. Unlike Bukkit/Spigot and Sponge, Fabric does not add permission checks for vanilla commands. This is not an issue with LuckPerms. However, since Fabric supports modifying the base game, you may install an additional mod to add those permission checks, such as [Minecraft Command Permissions](https://github.com/lucko/minecraft-command-permissions-fabric) or [Command Hider](https://github.com/LoganDark/fabric-command-hider).
 
 Also note that individual mods may not support permissions either, as permissions in Fabric are not yet as standardized as they are in Bukkit/Spigot or Sponge.
 


### PR DESCRIPTION
The required version of Fabric Loader has been out for a little while now. I'm not sure if it's acceptable to PR a link to my own mod here, but it has additional features not covered by Minecraft Command Permissions like the ability to control individual parameters (i.e. allow `/kill` but not `/kill @a`) and also modded commands (such as LuckPerms itself).

It does use the `command` prefix rather than `minecraft.command`. I'm strongly considering switching to `minecraft.command`, but that shouldn't matter too much here. The main reason I went with that is because it also includes modded commands.