### PR TITLE
+ Styled Chat & Styled Player List - Prefixes, Suffixes, & Meta

### DIFF
--- a/pages/Prefixes,-Suffixes-&-Meta.md
+++ b/pages/Prefixes,-Suffixes-&-Meta.md
@@ -121,8 +121,8 @@ Some popular tab/nametag formatting plugins which work with LuckPerms on BungeeC
 * [Nucleus](https://nucleuspowered.org/) - an "essentials" like plugin, which also includes a [module for chat formatting](https://nucleuspowered.org/docs/modules/chat.html).
 
 ### Fabric
-* [Styled Chat](https://modrinth.com/mod/styled-chat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
-* [Styled Player List](https://modrinth.com/mod/styledplayerlist) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
+* [Styled Chat](https://github.com/Patbox/StyledChat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
+* [Styled Player List](https://github.com/Patbox/StyledPlayerList) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
 * [GraphiXMod](https://github.com/lochnessdragon/GraphiXMod) - includes chat formatting, holograms, tablist and scoreboard.
 * [Chatter](https://github.com/Axieum/Chatter) - includes chat formatting and Discord integration
 

--- a/pages/Prefixes,-Suffixes-&-Meta.md
+++ b/pages/Prefixes,-Suffixes-&-Meta.md
@@ -121,8 +121,8 @@ Some popular tab/nametag formatting plugins which work with LuckPerms on BungeeC
 * [Nucleus](https://nucleuspowered.org/) - an "essentials" like plugin, which also includes a [module for chat formatting](https://nucleuspowered.org/docs/modules/chat.html).
 
 ### Fabric
-* [Styled Chat](https://modrinth.com/mod/styled-chat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu) - Note that manual configuration is required and you need to use the [LuckPerms PlaceholderAPI Addon](https://luckperms.net/download) for this mod to work with LuckPerms.
-* [Styled Player List](https://modrinth.com/mod/styledplayerlist) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu) - Note that manual configuration is required and you need to use the [LuckPerms PlaceholderAPI Addon](https://luckperms.net/download) for this mod to work with LuckPerms.
+* [Styled Chat](https://modrinth.com/mod/styled-chat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu) - Note that manual configuration is required and you need to use the [LuckPerms __Fabric__ PlaceholderAPI Addon](https://luckperms.net/download) for this mod to work with LuckPerms.
+* [Styled Player List](https://modrinth.com/mod/styledplayerlist) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu) - Note that manual configuration is required and you need to use the [LuckPerms __Fabric__ PlaceholderAPI Addon](https://luckperms.net/download) for this mod to work with LuckPerms.
 * [GraphiXMod](https://github.com/lochnessdragon/GraphiXMod) - includes chat formatting, holograms, tablist and scoreboard.
 * [Chatter](https://github.com/Axieum/Chatter) - includes chat formatting and Discord integration
 

--- a/pages/Prefixes,-Suffixes-&-Meta.md
+++ b/pages/Prefixes,-Suffixes-&-Meta.md
@@ -121,8 +121,8 @@ Some popular tab/nametag formatting plugins which work with LuckPerms on BungeeC
 * [Nucleus](https://nucleuspowered.org/) - an "essentials" like plugin, which also includes a [module for chat formatting](https://nucleuspowered.org/docs/modules/chat.html).
 
 ### Fabric
-* [Styled Chat](https://modrinth.com/mod/styled-chat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
-* [Styled Player List](https://modrinth.com/mod/styledplayerlist) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
+* [Styled Chat](https://modrinth.com/mod/styled-chat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu) - Note that manual configuration is required and you need to use the [LuckPerms PlaceholderAPI Addon](https://luckperms.net/download) for this mod to work with LuckPerms.
+* [Styled Player List](https://modrinth.com/mod/styledplayerlist) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu) - Note that manual configuration is required and you need to use the [LuckPerms PlaceholderAPI Addon](https://luckperms.net/download) for this mod to work with LuckPerms.
 * [GraphiXMod](https://github.com/lochnessdragon/GraphiXMod) - includes chat formatting, holograms, tablist and scoreboard.
 * [Chatter](https://github.com/Axieum/Chatter) - includes chat formatting and Discord integration
 

--- a/pages/Prefixes,-Suffixes-&-Meta.md
+++ b/pages/Prefixes,-Suffixes-&-Meta.md
@@ -121,8 +121,8 @@ Some popular tab/nametag formatting plugins which work with LuckPerms on BungeeC
 * [Nucleus](https://nucleuspowered.org/) - an "essentials" like plugin, which also includes a [module for chat formatting](https://nucleuspowered.org/docs/modules/chat.html).
 
 ### Fabric
-* [Styled Chat](https://github.com/Patbox/StyledChat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
-* [Styled Player List](https://github.com/Patbox/StyledPlayerList) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
+* [Styled Chat](https://modrinth.com/mod/styled-chat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
+* [Styled Player List](https://modrinth.com/mod/styledplayerlist) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
 * [GraphiXMod](https://github.com/lochnessdragon/GraphiXMod) - includes chat formatting, holograms, tablist and scoreboard.
 * [Chatter](https://github.com/Axieum/Chatter) - includes chat formatting and Discord integration
 

--- a/pages/Prefixes,-Suffixes-&-Meta.md
+++ b/pages/Prefixes,-Suffixes-&-Meta.md
@@ -121,6 +121,8 @@ Some popular tab/nametag formatting plugins which work with LuckPerms on BungeeC
 * [Nucleus](https://nucleuspowered.org/) - an "essentials" like plugin, which also includes a [module for chat formatting](https://nucleuspowered.org/docs/modules/chat.html).
 
 ### Fabric
+* [Styled Chat](https://modrinth.com/mod/styled-chat) - includes chat formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
+* [Styled Player List](https://modrinth.com/mod/styledplayerlist) - includes tablist formatting, uses [Fabric TextPlaceholderAPI](https://placeholders.pb4.eu)
 * [GraphiXMod](https://github.com/lochnessdragon/GraphiXMod) - includes chat formatting, holograms, tablist and scoreboard.
 * [Chatter](https://github.com/Axieum/Chatter) - includes chat formatting and Discord integration
 


### PR DESCRIPTION
These two mods are the only good solutions I've found for 1.19 chat/tablist formatting on Fabric, now that GraphiXMod and Chatter aren't actively updated to new versions anymore.