### PR TITLE
Update Credits.md

### DIFF
--- a/pages/Credits.md
+++ b/pages/Credits.md
@@ -45,7 +45,10 @@ Additionally, I'd like to thank the project's Discord moderators and helpers, pa
 ### Moderators
 * **\_11**
 * **aberdeener**
+* **DarkLaw**
 * **emilyy**
+* **Evident**
+* **Frying☆Pan**
 * **Jay**
 * **Larry**
 * **OmegaWeaponDev**
@@ -59,10 +62,7 @@ Additionally, I'd like to thank the project's Discord moderators and helpers, pa
 ### Helpers
 * **ANutley**
 * **ben**
-* **DarkLaw**
 * **Doctor Zod**
-* **Evident**
-* **Frying☆Pan**
 * **JG**
 * **Lord_Samosa**
 * **powercas_gamer**


### PR DESCRIPTION
This PR moves DarkLaw, Evident and Frying☆Pan to the Moderators list in the [credits](pages/Credits.md) page.