### PR TITLE
Added instructions for Velocity pre-setup including a note about modifications needed to `FabricProxy-Lite.toml` for Fabric servers

### DIFF
--- a/pages/Network-Installation.md
+++ b/pages/Network-Installation.md
@@ -12,6 +12,10 @@ Before you get started, there are a number of things you need to check. These ar
 
 LuckPerms supports networks using either `BungeeCord`, `Velocity` or `LilyPad`.
 
+### Velocity
+
+Setup Velocity following their [instructions](https://docs.papermc.io/velocity/getting-started/) and setup [modern forwarding](https://docs.papermc.io/velocity/player-information-forwarding/#configuring-modern-forwarding). Fabric servers will need `hackEarlySend` changed to `true` in `FabricProxy-Lite.toml`.
+
 ### BungeeCord
 LuckPerms uses a player's unique ids (UUID) as an index when saving data. A players uuid is provided by the server implementation, however, this value can depend on the state of the `online-mode` setting.
 


### PR DESCRIPTION
Pre setup was missing instructions for Velocity and I just spend 30 minutes searching to fix my problem due to missing a small note on [FabricProxy Lite](https://modrinth.com/mod/fabricproxy-lite)'s page. Having said note in LuckPerms docs (especially since it very much applies to LuckPerms) would have saved me time. So I added it to save someone else's time.